### PR TITLE
Run tests on PRs and rename old reference to master

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -3,13 +3,13 @@ name: Run tests
 on:
   push:
     branches-ignore:
-      - master
+      - production
+  pull_request:
+    branches: [ development ]
 
 jobs:
   build:
-
-    runs-on: macOS-latest
-
+    runs-on: macos-latest
     steps:
     - uses: actions/checkout@v1
     - name: Switch to Xcode 11.4


### PR DESCRIPTION
Cleans up the CI a bit:
* Rename `macOS` to `macos` to fix linting warning
* Rename old reference to `master`
* Run the tests when PRs are submitted