### PR TITLE
Use Dummy Secrets in Tests

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -19,14 +19,8 @@ jobs:
         cd Emitron
         bundle install
         bundle exec fastlane -v
-    - name: Download secrets
-      env:
-        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      run: |
-        scripts/download_s3.sh development > Emitron/Emitron/Configuration/secrets.development.xcconfig
-        scripts/download_s3.sh beta > Emitron/Emitron/Configuration/secrets.beta.xcconfig
-        scripts/download_s3.sh production > Emitron/Emitron/Configuration/secrets.production.xcconfig
+    - name: Generate secrets
+      run: scripts/generate_secrets.sh
     - name: Execute fastlane
       env:
         FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT: 5


### PR DESCRIPTION
Use the generate secrets script when running the unit tests. This allows CI to be run against PRs from forks to make it easier to accept contributions
