### PR TITLE
Change "Url"s to "URL"s

### DIFF
--- a/Emitron/Emitron/AppDelegate.swift
+++ b/Emitron/Emitron/AppDelegate.swift
@@ -57,7 +57,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     // swiftlint:disable:next force_try
     let dbPool = try! setupDatabase(application)
     persistenceStore = PersistenceStore(db: dbPool)
-    guardpost = Guardpost(baseUrl: "https://accounts.raywenderlich.com",
+    guardpost = Guardpost(baseURL: "https://accounts.raywenderlich.com",
                           urlScheme: "com.razeware.emitron://",
                           ssoSecret: Configuration.ssoSecret,
                           persistenceStore: persistenceStore)

--- a/Emitron/Emitron/Data/ViewModels/VideoPlaybackViewModel.swift
+++ b/Emitron/Emitron/Data/ViewModels/VideoPlaybackViewModel.swift
@@ -156,7 +156,7 @@ final class VideoPlaybackViewModel {
     // If we've got a download, then we might be ok
     if let download = contentItem.download,
       download.state == .complete,
-      download.localUrl != nil {
+      download.localURL != nil {
       // We have a download, but are we still authenticated?
       guard sessionController.hasCurrentDownloadPermissions
       else { throw Error.expiredPermissions }
@@ -374,8 +374,8 @@ private extension VideoPlaybackViewModel {
       // Is there a completed download?
       if let download = state.download,
         download.state == .complete,
-        let localUrl = download.localUrl {
-        let item = AVPlayerItem(url: localUrl)
+        let localURL = download.localURL {
+        let item = AVPlayerItem(url: localURL)
         self.addMetadata(from: state, to: item)
         self.addClosedCaptions(for: item)
         // Add it to the cache
@@ -431,7 +431,7 @@ private extension VideoPlaybackViewModel {
     artwork.identifier = .commonIdentifierArtwork
 
     let deferredArtwork = AVMetadataItem(propertiesOf: artwork) { request in
-      guard let url = state.content.cardArtworkUrl else {
+      guard let url = state.content.cardArtworkURL else {
         request.respond(error: Error.unableToLoadArtwork)
         return
       }

--- a/Emitron/Emitron/Displayable/ContentDisplayable.swift
+++ b/Emitron/Emitron/Displayable/ContentDisplayable.swift
@@ -119,7 +119,7 @@ protocol ContentListDisplayable: Ownable {
   var releasedAtDateTimeString: String { get }
   var parentName: String? { get }
   var contentType: ContentType { get }
-  var cardArtworkUrl: URL? { get }
+  var cardArtworkURL: URL? { get }
   var ordinal: Int? { get }
   var technologyTripleString: String { get }
   var contentSummaryMetadataString: String { get }

--- a/Emitron/Emitron/Displayable/ContentSummaryState+ContentListDisplayable.swift
+++ b/Emitron/Emitron/Displayable/ContentSummaryState+ContentListDisplayable.swift
@@ -58,8 +58,8 @@ extension ContentSummaryState: ContentListDisplayable {
     content.free
   }
   
-  var cardArtworkUrl: URL? {
-    content.cardArtworkUrl
+  var cardArtworkURL: URL? {
+    content.cardArtworkURL
   }
   
   var contentType: ContentType {

--- a/Emitron/Emitron/Downloads/DownloadProcessor.swift
+++ b/Emitron/Emitron/Downloads/DownloadProcessor.swift
@@ -31,8 +31,8 @@ import Combine
 
 protocol DownloadProcessorModel {
   var id: UUID { get }
-  var localUrl: URL? { get }
-  var remoteUrl: URL? { get }
+  var localURL: URL? { get }
+  var remoteURL: URL? { get }
 }
 
 protocol DownloadProcessorDelegate: AnyObject {
@@ -88,9 +88,9 @@ final class DownloadProcessor: NSObject {
 
 extension DownloadProcessor {
   func add(download: DownloadProcessorModel) throws {
-    guard let remoteUrl = download.remoteUrl else { throw DownloadProcessorError.invalidArguments }
+    guard let remoteURL = download.remoteURL else { throw DownloadProcessorError.invalidArguments }
     
-    let downloadTask = session.downloadTask(with: remoteUrl)
+    let downloadTask = session.downloadTask(with: remoteURL)
     downloadTask.downloadId = download.id
     downloadTask.resume()
     
@@ -187,11 +187,11 @@ extension DownloadProcessor: URLSessionDownloadDelegate {
       let delegate = delegate else { return }
     
     let download = delegate.downloadProcessor(self, downloadModelForDownloadWithId: downloadId)
-    guard let localUrl = download?.localUrl else { return }
+    guard let localURL = download?.localURL else { return }
     
     let fileManager = FileManager.default
     do {
-      try fileManager.moveItem(at: location, to: localUrl)
+      try fileManager.moveItem(at: location, to: localURL)
     } catch {
       delegate.downloadProcessor(self, downloadWithId: downloadId, didFailWithError: error)
     }
@@ -210,8 +210,8 @@ extension DownloadProcessor: URLSessionDownloadDelegate {
           newTask = session.downloadTask(withResumeData: resumeData)
         } else {
           let download = delegate.downloadProcessor(self, downloadModelForDownloadWithId: downloadId)
-          if let remoteUrl = download?.remoteUrl {
-            newTask = session.downloadTask(with: remoteUrl)
+          if let remoteURL = download?.remoteURL {
+            newTask = session.downloadTask(with: remoteURL)
           }
         }
         if let newTask = newTask {

--- a/Emitron/Emitron/Guardpost/Guardpost.swift
+++ b/Emitron/Emitron/Guardpost/Guardpost.swift
@@ -29,7 +29,7 @@
 import AuthenticationServices
 
 public enum LoginError: Error {
-  case unableToCreateLoginUrl
+  case unableToCreateLoginURL
   case errorResponseFromGuardpost(Error?)
   case unableToDecodeGuardpostResponse
   case invalidSignature
@@ -38,8 +38,8 @@ public enum LoginError: Error {
   public var localizedDescription: String {
     let prefix = "GuardpostLoginError::"
     switch self {
-    case .unableToCreateLoginUrl:
-      return "\(prefix)UnableToCreateLoginUrl"
+    case .unableToCreateLoginURL:
+      return "\(prefix)UnableToCreateLoginURL"
     case .errorResponseFromGuardpost(let error):
       return "\(prefix)GuardpostLoginError:: [Error: \(error?.localizedDescription ?? "UNKNOWN")]"
     case .unableToDecodeGuardpostResponse:
@@ -54,7 +54,7 @@ public enum LoginError: Error {
 
 public class Guardpost {
   // MARK: - Properties
-  private let baseUrl: String
+  private let baseURL: String
   private let urlScheme: String
   private let ssoSecret: String
   private var _currentUser: User?
@@ -70,29 +70,29 @@ public class Guardpost {
   }
 
   // MARK: - Initializers
-  init(baseUrl: String,
+  init(baseURL: String,
        urlScheme: String,
        ssoSecret: String,
        persistenceStore: PersistenceStore) {
-    self.baseUrl = baseUrl
+    self.baseURL = baseURL
     self.urlScheme = urlScheme
     self.ssoSecret = ssoSecret
     self.persistenceStore = persistenceStore
   }
 
   public func login(callback: @escaping (Result<User, LoginError>) -> Void) {
-    let guardpostLogin = "\(baseUrl)/v2/sso/login"
-    let returnUrl = "\(urlScheme)sessions/create"
+    let guardpostLogin = "\(baseURL)/v2/sso/login"
+    let returnURL = "\(urlScheme)sessions/create"
     let ssoRequest = SingleSignOnRequest(endpoint: guardpostLogin,
                                          secret: ssoSecret,
-                                         callbackUrl: returnUrl)
+                                         callbackURL: returnURL)
 
-    guard let loginUrl = ssoRequest.url else {
-      let result: Result<User, LoginError> = .failure(.unableToCreateLoginUrl)
+    guard let loginURL = ssoRequest.url else {
+      let result: Result<User, LoginError> = .failure(.unableToCreateLoginURL)
       return asyncResponse(callback: callback, result: result)
     }
 
-    authSession = ASWebAuthenticationSession(url: loginUrl,
+    authSession = ASWebAuthenticationSession(url: loginURL,
                                              callbackURLScheme: urlScheme) { url, error in
 
       var result: Result<User, LoginError>
@@ -102,7 +102,7 @@ public class Guardpost {
         return self.asyncResponse(callback: callback, result: result)
       }
 
-      guard let response = SingleSignOnResponse(request: ssoRequest, responseUrl: url) else {
+      guard let response = SingleSignOnResponse(request: ssoRequest, responseURL: url) else {
         result = .failure(LoginError.unableToDecodeGuardpostResponse)
         return self.asyncResponse(callback: callback, result: result)
       }

--- a/Emitron/Emitron/Guardpost/SSO/SingleSignOnRequest.swift
+++ b/Emitron/Emitron/Guardpost/SSO/SingleSignOnRequest.swift
@@ -32,7 +32,7 @@ import Foundation
 struct SingleSignOnRequest {
 
   // MARK: - Properties
-  private let callbackUrl: String
+  private let callbackURL: String
   let secret: String
   let nonce: String
   private let endpoint: String
@@ -45,10 +45,10 @@ struct SingleSignOnRequest {
   // MARK: - Initializers
   init(endpoint: String,
        secret: String,
-       callbackUrl: String) {
+       callbackURL: String) {
     self.endpoint = endpoint
     self.secret = secret
-    self.callbackUrl = callbackUrl
+    self.callbackURL = callbackURL
     nonce = randomHexString(length: 40)
   }
 }
@@ -77,7 +77,7 @@ private extension SingleSignOnRequest {
   var unsignedPayload: String? {
     var components = URLComponents()
     components.queryItems = [
-      URLQueryItem(name: "callback_url", value: callbackUrl),
+      URLQueryItem(name: "callback_url", value: callbackURL),
       URLQueryItem(name: "nonce", value: nonce)
     ]
     return components.query

--- a/Emitron/Emitron/Guardpost/SSO/SingleSignOnResponse.swift
+++ b/Emitron/Emitron/Guardpost/SSO/SingleSignOnResponse.swift
@@ -38,8 +38,8 @@ struct SingleSignOnResponse {
   private let decodedPayload: [URLQueryItem]?
 
   // MARK: - Initializers
-  init?(request: SingleSignOnRequest, responseUrl: URL) {
-    let responseComponents = URLComponents(url: responseUrl,
+  init?(request: SingleSignOnRequest, responseURL: URL) {
+    let responseComponents = URLComponents(url: responseURL,
                                            resolvingAgainstBaseURL: false)
     var components = URLComponents()
     guard

--- a/Emitron/Emitron/Models/Content.swift
+++ b/Emitron/Emitron/Models/Content.swift
@@ -41,7 +41,7 @@ struct Content: Codable {
   var contentType: ContentType
   var duration: Int
   var videoIdentifier: Int?
-  var cardArtworkUrl: URL?
+  var cardArtworkURL: URL?
   var technologyTriple: String
   var contributors: String
   var groupId: Int?
@@ -63,7 +63,7 @@ extension Content: Equatable {
       lhs.contentType == rhs.contentType &&
       lhs.duration == rhs.duration &&
       lhs.videoIdentifier == rhs.videoIdentifier &&
-      lhs.cardArtworkUrl == rhs.cardArtworkUrl &&
+      lhs.cardArtworkURL == rhs.cardArtworkURL &&
       lhs.technologyTriple == rhs.technologyTriple &&
       lhs.contributors == rhs.contributors &&
       lhs.groupId == rhs.groupId
@@ -84,7 +84,7 @@ extension Content {
             contentType: other.contentType,
             duration: other.duration,
             videoIdentifier: other.videoIdentifier,
-            cardArtworkUrl: other.cardArtworkUrl,
+            cardArtworkURL: other.cardArtworkURL,
             technologyTriple: other.technologyTriple,
             contributors: other.contributors,
             groupId: other.groupId ?? groupId,

--- a/Emitron/Emitron/Models/Download.swift
+++ b/Emitron/Emitron/Models/Download.swift
@@ -46,13 +46,13 @@ struct Download: Codable {
   var requestedAt: Date
   var lastValidatedAt: Date?
   var fileName: String?
-  var remoteUrl: URL?
+  var remoteURL: URL?
   var progress: Double = 0
   var state: State
   var contentId: Int
   var ordinal: Int = 0 // We copy this from the Content, and it is used to sort the queue
   
-  var localUrl: URL? {
+  var localURL: URL? {
     guard let fileName = fileName,
       let downloadDirectory = Download.downloadDirectory else {
         return nil
@@ -79,7 +79,7 @@ extension Download: Equatable {
   static func == (lhs: Download, rhs: Download) -> Bool {
     lhs.id == rhs.id &&
       lhs.fileName == rhs.fileName &&
-      lhs.remoteUrl == rhs.remoteUrl &&
+      lhs.remoteURL == rhs.remoteURL &&
       lhs.progress == rhs.progress &&
       lhs.state == rhs.state &&
       lhs.contentId == rhs.contentId &&
@@ -96,7 +96,7 @@ extension Download {
       requestedAt: Date(),
       lastValidatedAt: nil,
       fileName: nil,
-      remoteUrl: nil,
+      remoteURL: nil,
       progress: 0,
       state: .pending,
       contentId: content.id,
@@ -106,11 +106,11 @@ extension Download {
 
 extension Download {
   var isDownloading: Bool {
-    [.inProgress, .paused].contains(state) && remoteUrl != nil
+    [.inProgress, .paused].contains(state) && remoteURL != nil
   }
   
   var isDownloaded: Bool {
-    [.complete].contains(state) && remoteUrl != nil
+    [.complete].contains(state) && remoteURL != nil
   }
 }
 

--- a/Emitron/Emitron/Models/User.swift
+++ b/Emitron/Emitron/Models/User.swift
@@ -34,7 +34,7 @@ public struct User: Equatable, Codable {
   public let externalId: String
   public let email: String
   public let username: String
-  public let avatarUrl: URL
+  public let avatarURL: URL
   public let name: String
   public let token: String
   let permissions: [Permission]?
@@ -67,8 +67,8 @@ public struct User: Equatable, Codable {
       let externalId = dictionary["external_id"],
       let email = dictionary["email"],
       let username = dictionary["username"],
-      let avatarUrlString = dictionary["avatar_url"],
-      let avatarUrl = URL(string: avatarUrlString),
+      let avatarURLString = dictionary["avatar_url"],
+      let avatarURL = URL(string: avatarURLString),
       let name = dictionary["name"]?.replacingOccurrences(of: "+", with: " "),
       let token = dictionary["token"]
       else
@@ -77,7 +77,7 @@ public struct User: Equatable, Codable {
     self.externalId = externalId
     self.email = email
     self.username = username
-    self.avatarUrl = avatarUrl
+    self.avatarURL = avatarURL
     self.name = name
     self.token = token
     permissions = .none
@@ -87,7 +87,7 @@ public struct User: Equatable, Codable {
     externalId = user.externalId
     email = user.email
     username = user.username
-    avatarUrl = user.avatarUrl
+    avatarURL = user.avatarURL
     name = user.name
     token = user.token
     self.permissions = permissions

--- a/Emitron/Emitron/Networking/Adapters/EntityAdapters/ContentAdapter.swift
+++ b/Emitron/Emitron/Networking/Adapters/EntityAdapters/ContentAdapter.swift
@@ -57,9 +57,9 @@ struct ContentAdapter: EntityAdapter {
       }
     }
     
-    var cardArtworkUrl: URL?
-    if let cardArtworkUrlString = resource.attributes["card_artwork_url"] as? String {
-      cardArtworkUrl = URL(string: cardArtworkUrlString)
+    var cardArtworkURL: URL?
+    if let cardArtworkURLString = resource.attributes["card_artwork_url"] as? String {
+      cardArtworkURL = URL(string: cardArtworkURLString)
     }
     
     let group = relationships.first { relationship in
@@ -81,7 +81,7 @@ struct ContentAdapter: EntityAdapter {
                    contentType: contentType,
                    duration: duration,
                    videoIdentifier: resource.attributes["video_identifier"] as? Int,
-                   cardArtworkUrl: cardArtworkUrl,
+                   cardArtworkURL: cardArtworkURL,
                    technologyTriple: technologyTriple,
                    contributors: contributors,
                    groupId: groupId,

--- a/Emitron/Emitron/Networking/Network/RWEnvironment.swift
+++ b/Emitron/Emitron/Networking/Network/RWEnvironment.swift
@@ -31,9 +31,9 @@ import struct Foundation.URL
 struct RWEnvironment {
 
   // MARK: - Properties
-  var baseUrl: URL
+  var baseURL: URL
 }
 
 extension RWEnvironment {
-  static let prod = RWEnvironment(baseUrl: URL(string: "https://api.raywenderlich.com/api")!)
+  static let prod = RWEnvironment(baseURL: URL(string: "https://api.raywenderlich.com/api")!)
 }

--- a/Emitron/Emitron/Networking/Services/Service.swift
+++ b/Emitron/Emitron/Networking/Services/Service.swift
@@ -84,7 +84,7 @@ class Service {
 
   func prepare<R: Request>(request: R,
                            parameters: [Parameter]?) -> URLRequest? {
-    let pathURL = networkClient.environment.baseUrl.appendingPathComponent(request.path)
+    let pathURL = networkClient.environment.baseURL.appendingPathComponent(request.path)
 
     var components = URLComponents(url: pathURL,
                                    resolvingAgainstBaseURL: false)

--- a/Emitron/Emitron/Persistence/Models/Content+Persistence.swift
+++ b/Emitron/Emitron/Persistence/Models/Content+Persistence.swift
@@ -42,7 +42,7 @@ extension Content: FetchableRecord, TableRecord, PersistableRecord {
     static let contentType = Column("contentType")
     static let duration = Column("duration")
     static let videoIdentifier = Column("videoIdentifier")
-    static let cardArtworkUrl = Column("cardArtworkUrl")
+    static let cardArtworkURL = Column("cardArtworkURL")
     static let technologyTriple = Column("technologyTriple")
     static let contributors = Column("contributors")
     static let groupId = Column("groupId")

--- a/Emitron/Emitron/Persistence/Models/Download+Persistence.swift
+++ b/Emitron/Emitron/Persistence/Models/Download+Persistence.swift
@@ -34,7 +34,7 @@ extension Download: TableRecord, FetchableRecord, MutablePersistableRecord {
     static let requestedAt = Column("requestedAt")
     static let lastValidatedAt = Column("lastValidatedAt")
     static let fileName = Column("fileName")
-    static let remoteUrl = Column("remoteUrl")
+    static let remoteURL = Column("remoteURL")
     static let progress = Column("progress")
     static let state = Column("state")
     static let contentId = Column("contentId")

--- a/Emitron/Emitron/UI/Shared/Content Detail/ContentDetailView.swift
+++ b/Emitron/Emitron/UI/Shared/Content Detail/ContentDetailView.swift
@@ -126,7 +126,7 @@ struct ContentDetailView: View {
     VStack(spacing: 0, content: {
       ZStack(alignment: .center) {
         VerticalFadeImageView(
-          imageUrl: content.cardArtworkUrl,
+          imageURL: content.cardArtworkURL,
           blurred: false,
           width: width,
           height: min(width * imageRatio, maxImageHeight)
@@ -142,7 +142,7 @@ struct ContentDetailView: View {
   private func headerImageLockedProContent(for width: CGFloat) -> some View {
     ZStack {
       VerticalFadeImageView(
-        imageUrl: content.cardArtworkUrl,
+        imageURL: content.cardArtworkURL,
         blurred: true,
         width: width,
         height: min(width * imageRatio, maxImageHeight)

--- a/Emitron/Emitron/UI/Shared/Content Detail/VerticalFadeImageView.swift
+++ b/Emitron/Emitron/UI/Shared/Content Detail/VerticalFadeImageView.swift
@@ -30,14 +30,14 @@ import SwiftUI
 import KingfisherSwiftUI
 
 struct VerticalFadeImageView: View {
-  var imageUrl: URL?
+  var imageURL: URL?
   var blurred: Bool = false
   var width: CGFloat?
   var height: CGFloat?
   
   var body: some View {
     ZStack {
-      KFImage(imageUrl)
+      KFImage(imageURL)
         .resizable()
         .aspectRatio(contentMode: .fill)
         .frame(width: width, height: height, alignment: .top)
@@ -54,10 +54,10 @@ struct VerticalFadeImageView: View {
 struct VerticalFadeImageView_Previews: PreviewProvider {
   
   static var previews: some View {
-    VerticalFadeImageView(imageUrl: sampleImageUrl)
+    VerticalFadeImageView(imageURL: sampleImageURL)
   }
   
-  static var sampleImageUrl: URL? {
+  static var sampleImageURL: URL? {
     Bundle.main.url(forResource: "sampleCardImage", withExtension: "png")
   }
 }

--- a/Emitron/Emitron/UI/Shared/Content List/CardView.swift
+++ b/Emitron/Emitron/UI/Shared/Content List/CardView.swift
@@ -57,7 +57,7 @@ struct CardView: View {
 
           Spacer()
 
-          KFImage(model.cardArtworkUrl)
+          KFImage(model.cardArtworkURL)
             .resizable()
             .aspectRatio(contentMode: .fill)
             .frame(width: 60, height: 60)
@@ -154,7 +154,7 @@ struct MockContentListDisplayable: ContentListDisplayable {
   var duration: Int = 10080
   var parentName: String?
   var contentType: ContentType = .collection
-  var cardArtworkUrl: URL? = URL(string: "https://files.betamax.raywenderlich.com/attachments/collections/216/9eb9899d-47d0-429d-96f0-e15ac9542ecc.png")
+  var cardArtworkURL: URL? = URL(string: "https://files.betamax.raywenderlich.com/attachments/collections/216/9eb9899d-47d0-429d-96f0-e15ac9542ecc.png")
   var ordinal: Int?
   var technologyTripleString: String = "Doesn't matter"
   var contentSummaryMetadataString: String = "Doesn't matter"

--- a/Emitron/emitronScreenshots/SnapshotHelper.swift
+++ b/Emitron/emitronScreenshots/SnapshotHelper.swift
@@ -224,10 +224,10 @@ open class Snapshot: NSObject {
     guard let simulatorHostHome = ProcessInfo().environment["SIMULATOR_HOST_HOME"] else {
       throw SnapshotError.cannotFindSimulatorHomeDirectory
     }
-    guard let homeDirUrl = URL(string: simulatorHostHome) else {
+    guard let homeDirURL = URL(string: simulatorHostHome) else {
       throw SnapshotError.cannotAccessSimulatorHomeDirectory(simulatorHostHome)
     }
-    homeDir = URL(fileURLWithPath: homeDirUrl.path)
+    homeDir = URL(fileURLWithPath: homeDirURL.path)
     #else
     throw SnapshotError.cannotRunOnPhysicalDevice
     #endif

--- a/Emitron/emitronTests/Downloads/DownloadServiceTest.swift
+++ b/Emitron/emitronTests/Downloads/DownloadServiceTest.swift
@@ -513,8 +513,8 @@ class DownloadServiceTest: XCTestCase {
     XCTAssert(fileManager.fileExists(atPath: sampleFile.path))
   }
   
-  //: requestDownloadUrl() Tests
-  func testRequestDownloadUrlRequestsDownloadURLForEpisode() throws {
+  //: requestDownloadURL() Tests
+  func testRequestDownloadURLRequestsDownloadURLForEpisode() throws {
     let collection = ContentTest.Mocks.collection
     let fullState = ContentPersistableState.persistableState(for: collection.0, with: collection.1)
     let episode = fullState.childContents.first!
@@ -531,22 +531,22 @@ class DownloadServiceTest: XCTestCase {
     
     XCTAssertEqual(0, videoService.getVideoDownloadCount)
     
-    downloadService.requestDownloadUrl(downloadQueueItem)
+    downloadService.requestDownloadURL(downloadQueueItem)
     
     XCTAssertEqual(1, videoService.getVideoDownloadCount)
   }
   
-  func testRequestDownloadUrlRequestsDownloadsURLForScreencast() throws {
+  func testRequestDownloadURLRequestsDownloadsURLForScreencast() throws {
     let downloadQueueItem = try sampleDownloadQueueItem()
     
     XCTAssertEqual(0, videoService.getVideoDownloadCount)
     
-    downloadService.requestDownloadUrl(downloadQueueItem)
+    downloadService.requestDownloadURL(downloadQueueItem)
     
     XCTAssertEqual(1, videoService.getVideoDownloadCount)
   }
   
-  func testRequestDownloadUrlDoesNothingForCollection() throws {
+  func testRequestDownloadURLDoesNothingForCollection() throws {
     let collection = ContentTest.Mocks.collection
     let recorder = downloadService.requestDownload(contentId: collection.0.id) { _ in
       ContentPersistableState.persistableState(for: collection.0, with: collection.1)
@@ -566,7 +566,7 @@ class DownloadServiceTest: XCTestCase {
     XCTAssertEqual(0, videoService.getVideoDownloadCount)
   }
   
-  func testRequestDownloadUrlDoesNothingForDownloadInWrongState() throws {
+  func testRequestDownloadURLDoesNothingForDownloadInWrongState() throws {
     let downloadQueueItem = try sampleDownloadQueueItem()
     var download = downloadQueueItem.download
     
@@ -584,34 +584,34 @@ class DownloadServiceTest: XCTestCase {
     XCTAssertEqual(0, videoService.getVideoDownloadCount)
   }
   
-  func testRequestDownloadUrlUpdatesDownloadInCallback() throws {
+  func testRequestDownloadURLUpdatesDownloadInCallback() throws {
     let downloadQueueItem = try sampleDownloadQueueItem()
     
-    XCTAssertNil(downloadQueueItem.download.remoteUrl)
+    XCTAssertNil(downloadQueueItem.download.remoteURL)
     XCTAssertNil(downloadQueueItem.download.lastValidatedAt)
     XCTAssertEqual(Download.State.pending, downloadQueueItem.download.state)
     
-    downloadService.requestDownloadUrl(downloadQueueItem)
+    downloadService.requestDownloadURL(downloadQueueItem)
     
     try database.read { db in
       let download = try Download.fetchOne(db, key: downloadQueueItem.download.id)!
-      XCTAssertNotNil(download.remoteUrl)
+      XCTAssertNotNil(download.remoteURL)
       XCTAssertNotNil(download.lastValidatedAt)
     }
   }
   
-  func testRequestDownloadUrlRespectsTheUserPreferencesOnQuality() throws {
+  func testRequestDownloadURLRespectsTheUserPreferencesOnQuality() throws {
     let downloadQueueItem = try sampleDownloadQueueItem()
     let attachment = AttachmentTest.Mocks.downloads.0.first { $0.kind == .sdVideoFile }!
     
     SettingsManager.current.downloadQuality = .sdVideoFile
     
-    downloadService.requestDownloadUrl(downloadQueueItem)
+    downloadService.requestDownloadURL(downloadQueueItem)
     
     try database.read { db in
       let download = try Download.fetchOne(db, key: downloadQueueItem.download.id)!
-      XCTAssertNotNil(download.remoteUrl)
-      XCTAssertEqual(attachment.url, download.remoteUrl)
+      XCTAssertNotNil(download.remoteURL)
+      XCTAssertEqual(attachment.url, download.remoteURL)
     }
   }
   
@@ -619,19 +619,19 @@ class DownloadServiceTest: XCTestCase {
     let downloadQueueItem = try sampleDownloadQueueItem()
     let attachment = AttachmentTest.Mocks.downloads.0.first { $0.kind == .hdVideoFile }!
     
-    downloadService.requestDownloadUrl(downloadQueueItem)
+    downloadService.requestDownloadURL(downloadQueueItem)
     
     try database.read { db in
       let download = try Download.fetchOne(db, key: downloadQueueItem.download.id)!
-      XCTAssertNotNil(download.remoteUrl)
-      XCTAssertEqual(attachment.url, download.remoteUrl)
+      XCTAssertNotNil(download.remoteURL)
+      XCTAssertEqual(attachment.url, download.remoteURL)
     }
   }
   
   func testRequestDownloadUpdatesTheStateCorrectly() throws {
     let downloadQueueItem = try sampleDownloadQueueItem()
 
-    downloadService.requestDownloadUrl(downloadQueueItem)
+    downloadService.requestDownloadURL(downloadQueueItem)
     
     try database.read { db in
       let download = try Download.fetchOne(db, key: downloadQueueItem.download.id)!
@@ -643,7 +643,7 @@ class DownloadServiceTest: XCTestCase {
     let downloadQueueItem = try sampleDownloadQueueItem()
     var download = downloadQueueItem.download
     // Update to include the URL
-    download.remoteUrl = URL(string: "https://example.com/video.mp4")
+    download.remoteURL = URL(string: "https://example.com/video.mp4")
     download.state = .readyForDownload
     try database.write { db in
       try download.save(db)
@@ -654,7 +654,7 @@ class DownloadServiceTest: XCTestCase {
     
     try database.read { db in
       let refreshedDownload = try Download.fetchOne(db, key: download.id)!
-      XCTAssertNotNil(refreshedDownload.localUrl)
+      XCTAssertNotNil(refreshedDownload.localURL)
       XCTAssertNotNil(refreshedDownload.fileName)
       XCTAssertEqual(Download.State.enqueued, refreshedDownload.state)
     }
@@ -663,7 +663,7 @@ class DownloadServiceTest: XCTestCase {
   func testEnqueueUpdatesStateToCompletedIfItFindsDownload() throws {
     let downloadQueueItem = try sampleDownloadQueueItem()
     var download = downloadQueueItem.download
-    download.remoteUrl = URL(string: "https://example.com/amazing.mp4")
+    download.remoteURL = URL(string: "https://example.com/amazing.mp4")
     download.fileName = "\(downloadQueueItem.content.videoIdentifier!).mp4"
     download.state = .readyForDownload
     try database.write { db in
@@ -689,13 +689,13 @@ class DownloadServiceTest: XCTestCase {
     try database.read { db in
       let refreshedDownload = try Download.fetchOne(db, key: download.id)!
       XCTAssertEqual(Download.State.complete, refreshedDownload.state)
-      XCTAssertEqual(sampleFile, refreshedDownload.localUrl)
+      XCTAssertEqual(sampleFile, refreshedDownload.localURL)
     }
     
     try fileManager.removeItem(at: sampleFile)
   }
   
-  func testEnqueueDoesNothingForADownloadWithoutARemoteUrl() throws {
+  func testEnqueueDoesNothingForADownloadWithoutARemoteURL() throws {
     let downloadQueueItem = try sampleDownloadQueueItem()
     var download = downloadQueueItem.download
     download.state = .urlRequested
@@ -710,7 +710,7 @@ class DownloadServiceTest: XCTestCase {
     try database.read { db in
       let refreshedDownload = try Download.fetchOne(db, key: download.id)!
       XCTAssertNil(refreshedDownload.fileName)
-      XCTAssertNil(refreshedDownload.localUrl)
+      XCTAssertNil(refreshedDownload.localURL)
       XCTAssertEqual(Download.State.urlRequested, refreshedDownload.state)
     }
   }
@@ -718,7 +718,7 @@ class DownloadServiceTest: XCTestCase {
   func testEnqueueDoesNothingForDownloadInTheWrongState() throws {
     let downloadQueueItem = try sampleDownloadQueueItem()
     var download = downloadQueueItem.download
-    download.remoteUrl = URL(string: "https://example.com/amazing.mp4")
+    download.remoteURL = URL(string: "https://example.com/amazing.mp4")
     download.state = .pending
     try database.write { db in
       try download.save(db)
@@ -731,7 +731,7 @@ class DownloadServiceTest: XCTestCase {
     try database.read { db in
       let refreshedDownload = try Download.fetchOne(db, key: download.id)!
       XCTAssertNil(refreshedDownload.fileName)
-      XCTAssertNil(refreshedDownload.localUrl)
+      XCTAssertNil(refreshedDownload.localURL)
       XCTAssertEqual(Download.State.pending, refreshedDownload.state)
     }
   }

--- a/Emitron/emitronTests/Models/UserTest.swift
+++ b/Emitron/emitronTests/Models/UserTest.swift
@@ -53,7 +53,7 @@ class UserTest: XCTestCase {
     XCTAssertEqual(userDictionary["external_id"], user.externalId)
     XCTAssertEqual(userDictionary["email"], user.email)
     XCTAssertEqual(userDictionary["username"], user.username)
-    XCTAssertEqual(userDictionary["avatar_url"], user.avatarUrl.absoluteString)
+    XCTAssertEqual(userDictionary["avatar_url"], user.avatarURL.absoluteString)
     XCTAssertEqual(userDictionary["name"], user.name)
     XCTAssertEqual(userDictionary["token"], user.token)
   }

--- a/Emitron/emitronTests/Networking/Adapters/EntityAdapters/AttachmentAdapterTest.swift
+++ b/Emitron/emitronTests/Networking/Adapters/EntityAdapters/AttachmentAdapterTest.swift
@@ -73,7 +73,7 @@ class AttachmentAdapterTest: XCTestCase {
     }
   }
   
-  func testInvalidUrlThrows() throws {
+  func testInvalidURLThrows() throws {
     var sample = sampleResource
     sample["attributes"]["url"] = "this is not a valid URL"
     

--- a/Emitron/emitronTests/Networking/Adapters/EntityAdapters/ContentAdapterTest.swift
+++ b/Emitron/emitronTests/Networking/Adapters/EntityAdapters/ContentAdapterTest.swift
@@ -125,7 +125,7 @@ class ContentAdapterTest: XCTestCase {
     XCTAssertEqual(.collection, content.contentType)
     XCTAssertEqual(342, content.duration)
     let url = URL(string: "https://example.com/card_artwork.png")!
-    XCTAssertEqual(url, content.cardArtworkUrl)
+    XCTAssertEqual(url, content.cardArtworkURL)
     XCTAssertEqual("Swift 5, iOS 13.0 Beta, Xcode 11.0 Beta", content.technologyTriple)
     XCTAssertEqual("Katie Collins & Jessy Catterwaul", content.contributors)
     XCTAssertEqual(13, content.ordinal)
@@ -276,14 +276,14 @@ class ContentAdapterTest: XCTestCase {
     }
   }
   
-  func testInvalidCardArtworkUrlIsAcceptable() throws {
+  func testInvalidCardArtworkURLIsAcceptable() throws {
     var sample = sampleResource
     sample["attributes"]["card_artwork_url"] = JSON(NSNull())
     
     let resource = try makeJsonAPIResource(for: sample)
     
     let content = try ContentAdapter.process(resource: resource, relationships: relationships)
-    XCTAssertNil(content.cardArtworkUrl)
+    XCTAssertNil(content.cardArtworkURL)
   }
   
   func testMissingGroupIsAcceptable() throws {

--- a/Emitron/emitronTests/Persistence/Models/PersistenceMocks.swift
+++ b/Emitron/emitronTests/Persistence/Models/PersistenceMocks.swift
@@ -43,7 +43,7 @@ enum PersistenceMocks {
             contentType: .screencast,
             duration: 1234,
             videoIdentifier: nil,
-            cardArtworkUrl: URL(string: "https://example.com/card_artwork.png")!,
+            cardArtworkURL: URL(string: "https://example.com/card_artwork.png")!,
             technologyTriple: "Some Tech",
             contributors: "HELLO",
             groupId: nil,


### PR DESCRIPTION
Per https://swift.org/documentation/api-design-guidelines/:
"Acronyms and initialisms that commonly appear as all upper case in American English should be uniformly up- or down-cased according to case conventions"