### PR TITLE
Clarify access

### DIFF
--- a/Emitron/Emitron/UI/App Root/MainView.swift
+++ b/Emitron/Emitron/UI/App Root/MainView.swift
@@ -38,8 +38,11 @@ struct MainView: View {
       .background(Color.backgroundColor)
       .overlay(MessageBarView(messageBus: MessageBus.current), alignment: .bottom)
   }
-  
-  @ViewBuilder private var contentView: some View {
+}
+
+// MARK: - private
+private extension MainView {
+  @ViewBuilder var contentView: some View {
     if !sessionController.isLoggedIn {
       LoginView()
     } else if case .loaded = sessionController.permissionState {

--- a/Emitron/Emitron/UI/Empty States/NoResultsView.swift
+++ b/Emitron/Emitron/UI/Empty States/NoResultsView.swift
@@ -28,11 +28,23 @@
 
 import SwiftUI
 
-struct NoResultsView<Header: View>: View {
-  @EnvironmentObject var tabViewModel: TabViewModel
-  var contentScreen: ContentScreen
-  let header: Header
+struct NoResultsView<Header: View> {
+  init(
+    contentScreen: ContentScreen,
+    header: Header
+  ) {
+    self.contentScreen = contentScreen
+    self.header = header
+  }
 
+  @EnvironmentObject private var tabViewModel: TabViewModel
+
+  private let contentScreen: ContentScreen
+  private let header: Header
+}
+
+// MARK: - View
+extension NoResultsView: View {
   var body: some View {
     VStack {
       header

--- a/Emitron/Emitron/UI/Empty States/ReloadView.swift
+++ b/Emitron/Emitron/UI/Empty States/ReloadView.swift
@@ -28,10 +28,21 @@
 
 import SwiftUI
 
-struct ReloadView<Header: View>: View {
-  let header: Header
-  var reloadHandler: () -> Void
-  
+struct ReloadView<Header: View> {
+  init(
+    header: Header,
+    reloadHandler: @escaping () -> Void
+  ) {
+    self.header = header
+    self.reloadHandler = reloadHandler
+  }
+
+  private let header: Header
+  private let reloadHandler: () -> Void
+}
+
+// MARK: - View {
+extension ReloadView: View {
   var body: some View {
     VStack {
       header

--- a/Emitron/Emitron/UI/Library/SearchFieldView.swift
+++ b/Emitron/Emitron/UI/Library/SearchFieldView.swift
@@ -98,7 +98,7 @@ struct SearchFieldView_Previews: PreviewProvider {
     searchFields.colorScheme(.dark)
   }
   
-  static var searchFields: some View {
+  private static var searchFields: some View {
     VStack(spacing: 20) {
       SearchFieldView(searchString: "")
       SearchFieldView(searchString: "Hello")

--- a/Emitron/Emitron/UI/My Tutorials/MyTutorialsView.swift
+++ b/Emitron/Emitron/UI/My Tutorials/MyTutorialsView.swift
@@ -56,26 +56,42 @@ enum MyTutorialsState: String {
   }
 }
 
-struct MyTutorialView: View {
-  
+struct MyTutorialView {
+  init(
+    state: MyTutorialsState,
+    inProgressRepository: InProgressRepository,
+    completedRepository: CompletedRepository,
+    bookmarkRepository: BookmarkRepository,
+    domainRepository: DomainRepository
+  ) {
+    _state = .init(wrappedValue: state)
+    self.inProgressRepository = inProgressRepository
+    self.completedRepository = completedRepository
+    self.bookmarkRepository = bookmarkRepository
+    self.domainRepository = domainRepository
+  }
+
   // Initialization
-  @State var state: MyTutorialsState
+  @State private var state: MyTutorialsState
 
   // We need to pull these in to pass them to the settings view. We don't actually use them here.
   // I think this is a bug.
-  @EnvironmentObject var sessionController: SessionController
-  @EnvironmentObject var tabViewModel: TabViewModel
+  @EnvironmentObject private var sessionController: SessionController
+  @EnvironmentObject private var tabViewModel: TabViewModel
   
-  var inProgressRepository: InProgressRepository
-  var completedRepository: CompletedRepository
-  var bookmarkRepository: BookmarkRepository
-  @ObservedObject var domainRepository: DomainRepository
+  private let inProgressRepository: InProgressRepository
+  private let completedRepository: CompletedRepository
+  private let bookmarkRepository: BookmarkRepository
+  @ObservedObject private var domainRepository: DomainRepository
 
-  @State private var settingsPresented: Bool = false
-  @State private var reloadProgression: Bool = true
-  @State private var reloadCompleted: Bool = true
-  @State private var reloadBookmarks: Bool = true
+  @State private var settingsPresented = false
+  @State private var reloadProgression = true
+  @State private var reloadCompleted = true
+  @State private var reloadBookmarks = true
+}
 
+// MARK: - View
+extension MyTutorialView: View {
   var body: some View {
     contentView
       .navigationBarTitle(String.myTutorials)
@@ -100,8 +116,31 @@ struct MyTutorialView: View {
       reloadBookmarks = true
     }
   }
+}
 
-  private func makeContentListView(
+// MARK: - private
+private extension MyTutorialView {
+  @ViewBuilder var contentView: some View {
+    switch state {
+    case .inProgress:
+      makeContentListView(
+        contentRepository: inProgressRepository,
+        contentScreen: .inProgress
+      )
+    case .completed:
+      makeContentListView(
+        contentRepository: completedRepository,
+        contentScreen: .completed
+      )
+    case .bookmarked:
+      makeContentListView(
+        contentRepository: bookmarkRepository,
+        contentScreen: .bookmarked
+      )
+    }
+  }
+
+  func makeContentListView(
     contentRepository: ContentRepository,
     contentScreen: ContentScreen
   ) -> some View {
@@ -142,25 +181,5 @@ struct MyTutorialView: View {
       contentScreen: ContentScreen.inProgress,
       header: toggleControl
     )
-  }
-
-  @ViewBuilder private var contentView: some View {
-    switch state {
-    case .inProgress:
-      makeContentListView(
-        contentRepository: inProgressRepository,
-        contentScreen: .inProgress
-      )
-    case .completed:
-      makeContentListView(
-        contentRepository: completedRepository,
-        contentScreen: .completed
-      )
-    case .bookmarked:
-      makeContentListView(
-        contentRepository: bookmarkRepository,
-        contentScreen: .bookmarked
-      )
-    }
   }
 }

--- a/Emitron/Emitron/UI/Settings/SettingsList.swift
+++ b/Emitron/Emitron/UI/Settings/SettingsList.swift
@@ -53,7 +53,6 @@ struct SettingsList_Previews: PreviewProvider {
   }
 }
 
-
 // MARK: - internal
 extension SettingsList {
   init(settingsManager: ObservedObject<SettingsManager>) {

--- a/Emitron/Emitron/UI/Settings/SettingsList.swift
+++ b/Emitron/Emitron/UI/Settings/SettingsList.swift
@@ -28,17 +28,36 @@
 
 import SwiftUI
 
-struct SettingsList: View {
+struct SettingsList {
   @ObservedObject private var settingsManager: SettingsManager
+}
 
-  init(settingsManager: ObservedObject<SettingsManager>) {
-    _settingsManager = settingsManager
-  }
-  
+// MARK: - View
+extension SettingsList: View {
   var body: some View {
     VStack(spacing: 0) {
       ForEach(SettingsOption.allCases) { self[$0] }
     }
+  }
+}
+
+struct SettingsList_Previews: PreviewProvider {
+  static var previews: some View {
+    list.colorScheme(.dark)
+    list.colorScheme(.light)
+  }
+
+  static var list: some View {
+    SettingsList( settingsManager: .init(initialValue: .current) )
+      .background(Color.backgroundColor)
+  }
+}
+
+
+// MARK: - internal
+extension SettingsList {
+  init(settingsManager: ObservedObject<SettingsManager>) {
+    _settingsManager = settingsManager
   }
 }
 
@@ -75,19 +94,5 @@ private extension SettingsList {
         SettingsDisclosureRow(title: option.title, value: settingsManager.playbackSpeed.display)
       }
     }
-  }
-}
-
-struct SettingsList_Previews: PreviewProvider {
-  static var previews: some View {
-    SwiftUI.Group {
-      list.colorScheme(.dark)
-      list.colorScheme(.light)
-    }
-  }
-  
-  static var list: some View {
-    SettingsList( settingsManager: .init(initialValue: .current) )
-      .background(Color.backgroundColor)
   }
 }

--- a/Emitron/Emitron/UI/Shared/Content Detail/ChildContentListingView.swift
+++ b/Emitron/Emitron/UI/Shared/Content Detail/ChildContentListingView.swift
@@ -37,7 +37,10 @@ struct ChildContentListingView: View {
     childContentsViewModel.initialiseIfRequired()
     return courseDetailsSection
   }
-  
+}
+
+// MARK: - private
+private extension ChildContentListingView {
   @ViewBuilder private var courseDetailsSection: some View {
     switch childContentsViewModel.state {
     case .failed:
@@ -85,8 +88,27 @@ struct ChildContentListingView: View {
     }
     .padding(0)
   }
+
+  var loadingView: some View {
+    HStack {
+      Spacer()
+      LoadingView()
+      Spacer()
+    }
+      .listRowInsets(EdgeInsets())
+      .listRowBackground(Color.backgroundColor)
+      .background(Color.backgroundColor)
+  }
+
+  var reloadView: MainButtonView {
+    .init(
+      title: "Reload",
+      type: .primary(withArrow: false),
+      callback: childContentsViewModel.reload
+    )
+  }
   
-  private func episodeListing(data: [ChildContentListDisplayable]) -> some View {
+  func episodeListing(data: [ChildContentListDisplayable]) -> some View {
     let onlyContentWithVideoID = data
       .filter { $0.videoIdentifier != nil }
       .sorted {
@@ -100,8 +122,8 @@ struct ChildContentListingView: View {
         .listRowBackground(Color.backgroundColor)
     }
   }
-
-  @ViewBuilder private func episodeRow(model: ChildContentListDisplayable) -> some View {
+  
+  @ViewBuilder func episodeRow(model: ChildContentListDisplayable) -> some View {
     let childDynamicContentViewModel = childContentsViewModel.dynamicContentViewModel(for: model.id)
     
     if !sessionController.canPlay(content: model) {
@@ -137,25 +159,6 @@ struct ChildContentListingView: View {
         .padding([.horizontal, .bottom], 20)
       }
     }
-  }
-  
-  private var loadingView: some View {
-    HStack {
-      Spacer()
-      LoadingView()
-      Spacer()
-    }
-    .listRowInsets(EdgeInsets())
-    .listRowBackground(Color.backgroundColor)
-    .background(Color.backgroundColor)
-  }
-  
-  private var reloadView: MainButtonView {
-    .init(
-      title: "Reload",
-      type: .primary(withArrow: false),
-      callback: childContentsViewModel.reload
-    )
   }
 }
 

--- a/Emitron/Emitron/UI/Shared/Content Detail/ContentDetailView.swift
+++ b/Emitron/Emitron/UI/Shared/Content Detail/ContentDetailView.swift
@@ -28,25 +28,28 @@
 
 import SwiftUI
 
-struct ContentDetailView: View {
-  @State private var currentlyDisplayedVideoPlaybackViewModel: VideoPlaybackViewModel?
-  
-  var content: ContentListDisplayable
-  @ObservedObject var childContentsViewModel: ChildContentsViewModel
-  @ObservedObject var dynamicContentViewModel: DynamicContentViewModel
+struct ContentDetailView {
+  init(
+    content: ContentListDisplayable,
+    childContentsViewModel: ChildContentsViewModel,
+    dynamicContentViewModel: DynamicContentViewModel
+  ) {
+    self.content = content
+    self.childContentsViewModel = childContentsViewModel
+    self.dynamicContentViewModel = dynamicContentViewModel
+  }
 
-  @EnvironmentObject var sessionController: SessionController
-  var user: User {
-    sessionController.user!
-  }
-  
-  private var canStreamPro: Bool {
-    user.canStreamPro
-  }
-  
-  var imageRatio: CGFloat = 283 / 375
-  var maxImageHeight: CGFloat = 384
-  
+  private let content: ContentListDisplayable
+  @ObservedObject private var childContentsViewModel: ChildContentsViewModel
+  @ObservedObject private var dynamicContentViewModel: DynamicContentViewModel
+
+  @EnvironmentObject private var sessionController: SessionController
+
+  @State private var currentlyDisplayedVideoPlaybackViewModel: VideoPlaybackViewModel?
+}
+
+// MARK: - View
+extension ContentDetailView: View {
   var body: some View {
     ZStack {
       contentView
@@ -56,7 +59,10 @@ struct ContentDetailView: View {
       }
     }
   }
-  
+}
+
+// MARK: - private
+private extension ContentDetailView {
   var contentView: some View {
     GeometryReader { geometry in
       List {
@@ -84,8 +90,14 @@ struct ContentDetailView: View {
       .navigationBarTitle(Text(""), displayMode: .inline)
       .background(Color.backgroundColor)
   }
-  
-  private func openSettings() {
+
+  var canStreamPro: Bool { user.canStreamPro }
+  var user: User { sessionController.user! }
+
+  var imageRatio: CGFloat { 283 / 375 }
+  var maxImageHeight: CGFloat { 384 }
+
+  func openSettings() {
     // open iPhone settings
     if
       let url = URL(string: UIApplication.openSettingsURLString),
@@ -93,7 +105,7 @@ struct ContentDetailView: View {
     { UIApplication.shared.open(url) }
   }
   
-  private var continueOrPlayButton: some View {
+  var continueOrPlayButton: some View {
     Button(action: {
       currentlyDisplayedVideoPlaybackViewModel = dynamicContentViewModel.videoPlaybackViewModel(
         apiClient: sessionController.client,
@@ -118,7 +130,7 @@ struct ContentDetailView: View {
     }
   }
 
-  private func headerImagePlayableContent(for width: CGFloat) -> some View {
+  func headerImagePlayableContent(for width: CGFloat) -> some View {
     VStack(spacing: 0, content: {
       ZStack(alignment: .center) {
         VerticalFadeImageView(
@@ -135,7 +147,7 @@ struct ContentDetailView: View {
     })
   }
   
-  private func headerImageLockedProContent(for width: CGFloat) -> some View {
+  func headerImageLockedProContent(for width: CGFloat) -> some View {
     ZStack {
       VerticalFadeImageView(
         imageURL: content.cardArtworkURL,
@@ -148,7 +160,7 @@ struct ContentDetailView: View {
     }
   }
   
-  private var progressBar: ProgressBarView? {
+  var progressBar: ProgressBarView? {
     guard case .inProgress(let progress) = dynamicContentViewModel.viewProgress
     else { return nil }
 

--- a/Emitron/Emitron/UI/Shared/Content Detail/ContentSummaryView.swift
+++ b/Emitron/Emitron/UI/Shared/Content Detail/ContentSummaryView.swift
@@ -32,27 +32,27 @@ private enum Layout {
   static let buttonSize: CGFloat = 20
 }
 
-struct ContentSummaryView: View {
-  var content: ContentListDisplayable
-  @ObservedObject var dynamicContentViewModel: DynamicContentViewModel
-  @EnvironmentObject var sessionController: SessionController
+struct ContentSummaryView {
+  @EnvironmentObject private var sessionController: SessionController
+  private let content: ContentListDisplayable
+  @ObservedObject private var dynamicContentViewModel: DynamicContentViewModel
   @State private var deletionConfirmation: DownloadDeletionConfirmation?
-  
-  var courseLocked: Bool {
-    content.professional && !sessionController.user!.canStreamPro
+
+  init(
+    content: ContentListDisplayable,
+    dynamicContentViewModel: DynamicContentViewModel
+  ) {
+    self.content = content
+    self.dynamicContentViewModel = dynamicContentViewModel
   }
-  
-  var canDownload: Bool {
-    sessionController.user?.canDownload ?? false
-  }
-  
+}
+
+// MARK: - View
+extension ContentSummaryView: View {
   var body: some View {
     dynamicContentViewModel.initialiseIfRequired()
-    return contentView
-  }
-  
-  private var contentView: some View {
-    VStack(alignment: .leading) {
+    
+    return VStack(alignment: .leading) {
       HStack {
         Text(content.technologyTripleString.uppercased())
           .font(.uiUppercase)
@@ -108,8 +108,19 @@ struct ContentSummaryView: View {
         .lineSpacing(3)
     }
   }
+}
+
+// MARK: - private
+private extension ContentSummaryView {
+  var courseLocked: Bool {
+    content.professional && !sessionController.user!.canStreamPro
+  }
   
-  private var completedTag: CompletedTag? {
+  var canDownload: Bool {
+    sessionController.user?.canDownload ?? false
+  }
+
+  var completedTag: CompletedTag? {
     if case .completed = dynamicContentViewModel.viewProgress {
       return CompletedTag()
     }
@@ -129,11 +140,11 @@ struct ContentSummaryView: View {
       .accessibility(label: Text("Bookmark course"))
   }
   
-  private func download() {
+  func download() {
     deletionConfirmation = dynamicContentViewModel.downloadTapped()
   }
   
-  private func bookmark() {
+  func bookmark() {
     dynamicContentViewModel.bookmarkTapped()
   }
 }

--- a/Emitron/Emitron/UI/Shared/Content Detail/TextListItemView.swift
+++ b/Emitron/Emitron/UI/Shared/Content Detail/TextListItemView.swift
@@ -79,8 +79,11 @@ struct TextListItemView: View {
       }
     }
   }
+}
 
-  @ViewBuilder private var progressBar: some View {
+// MARK: - private
+private extension TextListItemView {
+  @ViewBuilder var progressBar: some View {
     if case .inProgress(let progress) = dynamicContentViewModel.viewProgress {
       ProgressBarView(progress: progress, isRounded: true)
     } else {
@@ -102,11 +105,11 @@ struct TextListItemView: View {
     }
   }
   
-  private func download() {
+  func download() {
     deletionConfirmation = dynamicContentViewModel.downloadTapped()
   }
   
-  private func toggleCompleteness() {
+  func toggleCompleteness() {
     dynamicContentViewModel.completedTapped()
   }
 }

--- a/Emitron/Emitron/UI/Shared/Content Detail/VerticalFadeImageView.swift
+++ b/Emitron/Emitron/UI/Shared/Content Detail/VerticalFadeImageView.swift
@@ -29,12 +29,27 @@
 import SwiftUI
 import KingfisherSwiftUI
 
-struct VerticalFadeImageView: View {
-  var imageURL: URL?
-  var blurred: Bool = false
-  var width: CGFloat?
-  var height: CGFloat?
-  
+struct VerticalFadeImageView {
+  private let imageURL: URL?
+  private let blurred: Bool
+  private let width: CGFloat?
+  private let height: CGFloat?
+
+  init(
+    imageURL: URL?,
+    blurred: Bool,
+    width: CGFloat?,
+    height: CGFloat?
+  ) {
+    self.imageURL = imageURL
+    self.blurred = blurred
+    self.width = width
+    self.height = height
+  }
+}
+
+// MARK: - View
+extension VerticalFadeImageView: View {
   var body: some View {
     ZStack {
       KFImage(imageURL)
@@ -54,12 +69,9 @@ struct VerticalFadeImageView: View {
 }
 
 struct VerticalFadeImageView_Previews: PreviewProvider {
-  
   static var previews: some View {
-    VerticalFadeImageView(imageURL: sampleImageURL)
-  }
-  
-  static var sampleImageURL: URL? {
-    Bundle.main.url(forResource: "sampleCardImage", withExtension: "png")
+    Bundle.main.url(forResource: "sampleCardImage", withExtension: "png").map {
+      VerticalFadeImageView(imageURL: $0, blurred: false, width: nil, height: nil)
+    }
   }
 }

--- a/Emitron/Emitron/UI/Video/FullScreenVideoPlayerViewController.swift
+++ b/Emitron/Emitron/UI/Video/FullScreenVideoPlayerViewController.swift
@@ -42,7 +42,7 @@ class FullScreenVideoPlayerViewController: UIViewController {
     verifyVideoPlaybackAllowed()
   }
 
-  required init?(coder: NSCoder) {
+  @available(*, unavailable) required init?(coder: NSCoder) {
     preconditionFailure("init(coder:) has not been implemented")
   }
 }


### PR DESCRIPTION
Organizing some files into access control-based extensions was useful for getting clarity on what is actually mutable, and where properties need to be accessible.