### PR TITLE
Pause audio when video player is minimized

### DIFF
--- a/Emitron/Emitron/Data/ViewModels/VideoPlaybackViewModel.swift
+++ b/Emitron/Emitron/Data/ViewModels/VideoPlaybackViewModel.swift
@@ -204,7 +204,6 @@ final class VideoPlaybackViewModel {
     self.shouldBePlaying = false
     self.player.pause()
   }
-
 }
 
 // MARK: - private

--- a/Emitron/Emitron/Data/ViewModels/VideoPlaybackViewModel.swift
+++ b/Emitron/Emitron/Data/ViewModels/VideoPlaybackViewModel.swift
@@ -199,6 +199,12 @@ final class VideoPlaybackViewModel {
     shouldBePlaying = false
     player.pause()
   }
+
+  func stop() {
+    self.shouldBePlaying = false
+    self.player.pause()
+  }
+
 }
 
 // MARK: - private

--- a/Emitron/Emitron/UI/Video/FullScreenVideoPlayerViewController.swift
+++ b/Emitron/Emitron/UI/Video/FullScreenVideoPlayerViewController.swift
@@ -79,6 +79,7 @@ extension FullScreenVideoPlayerViewController {
   }
   
   private func disappear() {
+    self.viewModel?.stop()
     dismiss(animated: true) {
       self.viewModel = nil
     }


### PR DESCRIPTION
This is for bug: https://github.com/razeware/emitron-iOS/issues/460

This bug's root problem is that in some cases, SwiftUI does not deallocate the VideoPlaybackViewModel even though the model is set to nil. This means the audio will keep playing even though the video is dismissed. In those cases, the only way to stop the audio is to navigate back to the Library view or restart the app.

For a bandaid fix, I created a stop method in the view model. This will pause audio playback although the object still exists in memory. Objects will continue to accumulate until the user goes back to the Library view at which point all the objects are deallocated.

In cases where the behavior works as expected, the video will just pause before deallocation. 

 