### PR TITLE
Section header fix (#465)

### DIFF
--- a/Emitron/Emitron/UI/Library/SearchFieldView.swift
+++ b/Emitron/Emitron/UI/Library/SearchFieldView.swift
@@ -44,7 +44,7 @@ struct SearchFieldView: View {
       Image(systemName: "magnifyingglass")
         .foregroundColor(.searchFieldIcon)
         .frame(height: 25)
-      
+
       TextField(
         String.search,
         text: $searchString,

--- a/Emitron/Emitron/UI/Shared/Content Detail/ChildContentListingView.swift
+++ b/Emitron/Emitron/UI/Shared/Content Detail/ChildContentListingView.swift
@@ -50,29 +50,31 @@ struct ChildContentListingView: View {
   }
   
   var coursesSection: some View {
-    Section {
-      if childContentsViewModel.contents.count > 1 {
-        Text("Course Episodes")
-          .font(.uiTitle2)
-          .foregroundColor(.titleText)
-          .padding([.top, .bottom])
+    SwiftUI.Group {
+      Section {
+        if childContentsViewModel.contents.count > 1 {
+          Text("Course Episodes")
+            .font(.uiTitle2)
+            .foregroundColor(.titleText)
+            .padding([.top, .bottom])
+        }
       }
-      .listRowBackground(Color.backgroundColor)
-      .accessibility(identifier: "childContentList")
-      
+        .listRowBackground(Color.backgroundColor)
+        .accessibility(identifier: "childContentList")
+        
       if childContentsViewModel.groups.count > 1 {
         ForEach(childContentsViewModel.groups, id: \.id) { group in
           // By default, iOS 14 shows headers in upper case. Text casing is changed by the textCase modifier which is not available on previous versions.
           if #available(iOS 14, *) {
             Section(header: CourseHeaderView(name: group.name)) {
-              self.episodeListing(data: self.childContentsViewModel.contents(for: group.id))
+              episodeListing(data: childContentsViewModel.contents(for: group.id))
             }
             .background(Color.backgroundColor)
             .textCase(nil)
           } else {
             // Default behavior for iOS 13 and lower.
             Section(header: CourseHeaderView(name: group.name)) {
-              self.episodeListing(data: self.childContentsViewModel.contents(for: group.id))
+              episodeListing(data: childContentsViewModel.contents(for: group.id))
             }
             .background(Color.backgroundColor)
           }

--- a/Emitron/Emitron/UI/Shared/Content Detail/ChildContentListingView.swift
+++ b/Emitron/Emitron/UI/Shared/Content Detail/ChildContentListingView.swift
@@ -62,8 +62,19 @@ struct ChildContentListingView: View {
       
       if childContentsViewModel.groups.count > 1 {
         ForEach(childContentsViewModel.groups, id: \.id) { group in
-          Section(header: CourseHeaderView(name: group.name)) {
-            episodeListing(data: childContentsViewModel.contents(for: group.id))
+          // By default, iOS 14 shows headers in upper case. Text casing is changed by the textCase modifier which is not available on previous versions.
+          if #available(iOS 14, *) {
+            Section(header: CourseHeaderView(name: group.name)) {
+              self.episodeListing(data: self.childContentsViewModel.contents(for: group.id))
+            }
+            .background(Color.backgroundColor)
+            .textCase(nil)
+          } else {
+            // Default behavior for iOS 13 and lower.
+            Section(header: CourseHeaderView(name: group.name)) {
+              self.episodeListing(data: self.childContentsViewModel.contents(for: group.id))
+            }
+            .background(Color.backgroundColor)
           }
         }
       } else if !childContentsViewModel.groups.isEmpty {

--- a/Emitron/Emitron/UI/Shared/Content Detail/ChildContentListingView.swift
+++ b/Emitron/Emitron/UI/Shared/Content Detail/ChildContentListingView.swift
@@ -55,21 +55,22 @@ struct ChildContentListingView: View {
         Text("Course Episodes")
           .font(.uiTitle2)
           .foregroundColor(.titleText)
-          .padding([.top], -5)
-        
-        if childContentsViewModel.groups.count > 1 {
-          ForEach(childContentsViewModel.groups, id: \.id) { group in
-            Section(header: CourseHeaderView(name: group.name)) {
-              episodeListing(data: childContentsViewModel.contents(for: group.id))
-            }
+          .padding([.top, .bottom])
+      }
+      .listRowBackground(Color.backgroundColor)
+      .accessibility(identifier: "childContentList")
+      
+      if childContentsViewModel.groups.count > 1 {
+        ForEach(childContentsViewModel.groups, id: \.id) { group in
+          Section(header: CourseHeaderView(name: group.name)) {
+            episodeListing(data: childContentsViewModel.contents(for: group.id))
           }
-        } else if !childContentsViewModel.groups.isEmpty {
-          episodeListing(data: childContentsViewModel.contents)
         }
+      } else if !childContentsViewModel.groups.isEmpty {
+        episodeListing(data: childContentsViewModel.contents)
       }
     }
-    .listRowBackground(Color.backgroundColor)
-    .accessibility(identifier: "childContentList")
+    .padding(0)
   }
   
   private func episodeListing(data: [ChildContentListDisplayable]) -> some View {

--- a/Emitron/Emitron/UI/Shared/Content Detail/CourseHeaderView.swift
+++ b/Emitron/Emitron/UI/Shared/Content Detail/CourseHeaderView.swift
@@ -27,6 +27,7 @@
 // THE SOFTWARE.
 
 import SwiftUI
+import UIKit
 
 struct CourseHeaderView: View {
   let name: String
@@ -36,11 +37,8 @@ struct CourseHeaderView: View {
       Text(name)
         .font(.uiTitle3)
         .foregroundColor(.titleText)
-      
-      Rectangle()
-        .fill(Color.borderColor)
-        .frame(height: 1)
     }
+    .frame(minWidth: UIScreen.main.bounds.width)
     .padding([.bottom], 16)
   }
 }

--- a/Emitron/Emitron/UI/Shared/Content Detail/CourseHeaderView.swift
+++ b/Emitron/Emitron/UI/Shared/Content Detail/CourseHeaderView.swift
@@ -34,10 +34,15 @@ struct CourseHeaderView: View {
   
   var body: some View {
     VStack(alignment: .leading, spacing: 12) {
-      Text(name)
-        .font(.uiTitle3)
-        .foregroundColor(.titleText)
+      HStack {
+        Text(name)
+          .font(.uiTitle3)
+          .foregroundColor(.titleText)
+          .padding(.leading, 20)
+        Spacer()
+      }
     }
+
     .frame(minWidth: UIScreen.main.bounds.width)
     .padding([.bottom], 16)
   }


### PR DESCRIPTION
This pull request resolves the issue with additional lines rendering in iOS 14. This was due to list sections being nested inside of each other. This pull request refactors the sections inside of a group that resolves the issue. It also sets the width of the list cell to the width of the device.
 
Before:

![Screen Shot 2020-09-14 at 2 53 04 PM](https://user-images.githubusercontent.com/973751/93126180-0ce5ba80-f69a-11ea-9f1c-4e9b8fc75609.png)

After:

![Screen Shot 2020-09-14 at 2 41 32 PM](https://user-images.githubusercontent.com/973751/93125756-934dcc80-f699-11ea-82a9-0fc85572e0ae.png)

Note: The project contains a Group struct that causes a name collision with the SwiftUI Group. 
