### PR TITLE
Filters: Black bar visible at bottom #490

### DIFF
--- a/Emitron/Emitron/UI/Library/LibraryView.swift
+++ b/Emitron/Emitron/UI/Library/LibraryView.swift
@@ -47,7 +47,7 @@ struct LibraryView: View {
       )
       .sheet(isPresented: $filtersPresented) {
         FiltersView(libraryRepository: libraryRepository, filters: filters)
-          .background(Color.backgroundColor)
+          .background(Color.backgroundColor.edgesIgnoringSafeArea(.all))
       }
   }
   


### PR DESCRIPTION
Add fix to add background color to area under sheet.

<!-- 🚀 Thank you for contributing! -->

<!-- Describe your changes clearly and use examples if possible. -->
Description: The fix is to include the safe area within the background/color view.

<!-- If this PR fixes an issue, then please link to that issue. If the PR
  is large (or likely to be), it would be prudent to open a discussion in
  advance of the PR to avoid doing large amounts of work that might not
  get merged. -->
Issue: https://github.com/razeware/emitron-iOS/issues/497
<!-- When this PR is merged, a new version of emitron will be pushed to Testflight automatically -->
