### PR TITLE
Lock Tag icon height for time-being to prevent parent view rendering issue

### DIFF
--- a/Emitron/Emitron/UI/Shared/Tags/TagView.swift
+++ b/Emitron/Emitron/UI/Shared/Tags/TagView.swift
@@ -30,6 +30,7 @@ import SwiftUI
 
 struct TagView: View {
   private static let defaultIconHeight: CGFloat = 12.0
+  
   private struct SizeKey: PreferenceKey {
     static func reduce(value: inout CGSize?, nextValue: () -> CGSize?) {
       value = value ?? nextValue()

--- a/Emitron/Emitron/UI/Shared/Tags/TagView.swift
+++ b/Emitron/Emitron/UI/Shared/Tags/TagView.swift
@@ -29,6 +29,7 @@
 import SwiftUI
 
 struct TagView: View {
+  private static let defaultIconHeight: CGFloat = 12.0
   private struct SizeKey: PreferenceKey {
     static func reduce(value: inout CGSize?, nextValue: () -> CGSize?) {
       value = value ?? nextValue()
@@ -49,7 +50,7 @@ struct TagView: View {
         .resizable()
         .aspectRatio(contentMode: .fit)
         .foregroundColor(textColor)
-        .frame(height: height)
+        .frame(height: Self.defaultIconHeight)
       
       Text(text.uppercased())
         .foregroundColor(textColor)


### PR DESCRIPTION
<!-- 🚀 Thank you for contributing! -->

<!-- Describe your changes clearly and use examples if possible. -->
Locking TagView icon height for time-being to resolve size rendering issue 
If you accept the PR, would you mind adding the `hacktoberfest-accepted` label?

<!-- If this PR fixes an issue, then please link to that issue. If the PR
  is large (or likely to be), it would be prudent to open a discussion in
  advance of the PR to avoid doing large amounts of work that might not
  get merged. -->
https://github.com/razeware/emitron-iOS/issues/493
<!-- When this PR is merged, a new version of emitron will be pushed to Testflight automatically -->
