### PR TITLE
Hide download settings from the users who don't have download access

### DIFF
--- a/Emitron/Emitron/Models/SettingsOption.swift
+++ b/Emitron/Emitron/Models/SettingsOption.swift
@@ -84,3 +84,14 @@ enum SettingsOption: Int, Identifiable, CaseIterable {
     }
   }
 }
+
+// MARK: - Option Selection
+extension SettingsOption {
+  static func getOptions(for canDownload: Bool) -> [SettingsOption] {
+    if canDownload {
+      return SettingsOption.allCases
+    } else {
+      return [.playbackSpeed, .closedCaptionOn]
+    }
+  }
+}

--- a/Emitron/Emitron/UI/Settings/SettingsList.swift
+++ b/Emitron/Emitron/UI/Settings/SettingsList.swift
@@ -30,13 +30,14 @@ import SwiftUI
 
 struct SettingsList {
   @ObservedObject private var settingsManager: SettingsManager
+  private var canDownload: Bool
 }
 
 // MARK: - View
 extension SettingsList: View {
   var body: some View {
     VStack(spacing: 0) {
-      ForEach(SettingsOption.allCases) { self[$0] }
+      ForEach(SettingsOption.getOptions(for: canDownload)) { self[$0] }
     }
   }
 }
@@ -48,15 +49,16 @@ struct SettingsList_Previews: PreviewProvider {
   }
 
   static var list: some View {
-    SettingsList( settingsManager: .init(initialValue: .current) )
+    SettingsList(settingsManager: .init(initialValue: .current), canDownload: true)
       .background(Color.backgroundColor)
   }
 }
 
 // MARK: - internal
 extension SettingsList {
-  init(settingsManager: ObservedObject<SettingsManager>) {
+  init(settingsManager: ObservedObject<SettingsManager>, canDownload: Bool) {
     _settingsManager = settingsManager
+    self.canDownload = canDownload
   }
 }
 

--- a/Emitron/Emitron/UI/Settings/SettingsView.swift
+++ b/Emitron/Emitron/UI/Settings/SettingsView.swift
@@ -45,7 +45,10 @@ struct SettingsView: View {
   var body: some View {
     NavigationView {
       VStack {
-        SettingsList(settingsManager: _settingsManager)
+        SettingsList(
+          settingsManager: _settingsManager,
+          canDownload: sessionController.user?.canDownload ?? false
+        )
           .navigationBarTitle(String.settings)
           .navigationBarItems(trailing: dismissButton)
           .padding([.horizontal], 20)


### PR DESCRIPTION
Hide download settings from the users who don't have download access to fix #495 and also add a helper method to get appropriate SettingsOptions which might be helpful in the future to introduce new Options.
