### PR TITLE
Disable sort controls when fetching data

### DIFF
--- a/Emitron/Emitron/Assets.xcassets/Colours/Text/Contents.json
+++ b/Emitron/Emitron/Assets.xcassets/Colours/Text/Contents.json
@@ -1,6 +1,6 @@
 {
   "info" : {
-    "version" : 1,
-    "author" : "xcode"
+    "author" : "xcode",
+    "version" : 1
   }
 }

--- a/Emitron/Emitron/Assets.xcassets/Colours/Text/textButtonTextDisabled.colorset/Contents.json
+++ b/Emitron/Emitron/Assets.xcassets/Colours/Text/textButtonTextDisabled.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "1.000",
+          "green" : "1.000",
+          "red" : "1.000"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "1.000",
+          "green" : "1.000",
+          "red" : "1.000"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Emitron/Emitron/UI/Library/LibraryView.swift
+++ b/Emitron/Emitron/UI/Library/LibraryView.swift
@@ -27,7 +27,6 @@
 // THE SOFTWARE.
 
 import SwiftUI
-import Combine
 
 private extension CGFloat {
   static let filterButtonSide: CGFloat = 27
@@ -115,7 +114,7 @@ struct LibraryView: View {
               .foregroundColor(.textButtonText)
           }
         }
-      }.disabled(libraryRepository.state == .loading || libraryRepository.state == .loadingAdditional)
+      }.disabled([.loading, .loadingAdditional].contains(libraryRepository.state))
     }
   }
 

--- a/Emitron/Emitron/UI/Library/LibraryView.swift
+++ b/Emitron/Emitron/UI/Library/LibraryView.swift
@@ -27,6 +27,7 @@
 // THE SOFTWARE.
 
 import SwiftUI
+import Combine
 
 private extension CGFloat {
   static let filterButtonSide: CGFloat = 27
@@ -39,6 +40,7 @@ struct LibraryView: View {
   @ObservedObject var filters: Filters
   @ObservedObject var libraryRepository: LibraryRepository
   @State var filtersPresented: Bool = false
+  @State var isSorting: Bool = true
 
   var body: some View {
     contentView
@@ -49,8 +51,16 @@ struct LibraryView: View {
         FiltersView(libraryRepository: libraryRepository, filters: filters)
           .background(Color.backgroundColor.edgesIgnoringSafeArea(.all))
       }
+      .onReceive(Just(contentView)) {_ in
+        switch libraryRepository.state {
+        case .loading, .loadingAdditional:
+          isSorting = true
+        default:
+          isSorting = false
+        }
+      }
   }
-  
+
   private var contentControlsSection: some View {
     VStack {
       searchAndFilterControls
@@ -104,12 +114,17 @@ struct LibraryView: View {
         HStack {
           Image("sort")
             .foregroundColor(.textButtonText)
-
-          Text(filters.sortFilter.name)
-            .font(.uiLabelBold)
-            .foregroundColor(.textButtonText)
+          if isSorting {
+            Text(filters.sortFilter.name)
+              .font(.uiLabel)
+              .foregroundColor(Color.gray)
+          } else {
+            Text(filters.sortFilter.name)
+              .font(.uiLabelBold)
+              .foregroundColor(.textButtonText)
+          }
         }
-      }
+      }.disabled(isSorting)
     }
   }
 
@@ -147,6 +162,7 @@ struct LibraryView: View {
   }
 
   private func changeSort() {
+    isSorting = true
     filters.changeSortFilter()
     libraryRepository.filters = filters
   }

--- a/Emitron/Emitron/UI/Library/LibraryView.swift
+++ b/Emitron/Emitron/UI/Library/LibraryView.swift
@@ -40,7 +40,6 @@ struct LibraryView: View {
   @ObservedObject var filters: Filters
   @ObservedObject var libraryRepository: LibraryRepository
   @State var filtersPresented: Bool = false
-  @State var isSorting: Bool = true
 
   var body: some View {
     contentView
@@ -50,14 +49,6 @@ struct LibraryView: View {
       .sheet(isPresented: $filtersPresented) {
         FiltersView(libraryRepository: libraryRepository, filters: filters)
           .background(Color.backgroundColor.edgesIgnoringSafeArea(.all))
-      }
-      .onReceive(Just(contentView)) {_ in
-        switch libraryRepository.state {
-        case .loading, .loadingAdditional:
-          isSorting = true
-        default:
-          isSorting = false
-        }
       }
   }
 
@@ -114,7 +105,7 @@ struct LibraryView: View {
         HStack {
           Image("sort")
             .foregroundColor(.textButtonText)
-          if isSorting {
+          if [.loading, .loadingAdditional].contains(libraryRepository.state) {
             Text(filters.sortFilter.name)
               .font(.uiLabel)
               .foregroundColor(Color.gray)
@@ -124,7 +115,7 @@ struct LibraryView: View {
               .foregroundColor(.textButtonText)
           }
         }
-      }.disabled(isSorting)
+      }.disabled(libraryRepository.state == .loading || libraryRepository.state == .loadingAdditional)
     }
   }
 
@@ -162,7 +153,6 @@ struct LibraryView: View {
   }
 
   private func changeSort() {
-    isSorting = true
     filters.changeSortFilter()
     libraryRepository.filters = filters
   }


### PR DESCRIPTION
At the moment, when the user taps the sorting button (popularity, most recent), the app will make a request to the server. This request can be very slow which means the end-user can keep tapping the sort button. This results with the sort state being out of sync with the actual returned results.

To solve this issue, I've locked the buttons. This means that the user won't be able to change the sort order once they tapped the button. I've changed the font of the button to signify it is no longer tappable. 

![IMG_0108](https://user-images.githubusercontent.com/973751/97330132-3cb5df80-184e-11eb-9ff0-5c62e3b1feb6.png)
![IMG_0107](https://user-images.githubusercontent.com/973751/97330151-42abc080-184e-11eb-8622-9e62a11755e5.png)
![IMG_0110](https://user-images.githubusercontent.com/973751/97330177-493a3800-184e-11eb-8682-ce769d8b1fae.png)
![IMG_0109](https://user-images.githubusercontent.com/973751/97330186-4ccdbf00-184e-11eb-9902-d29f873ce98e.png)
