### PR TITLE
Change the filter view per Luke's design

### DIFF
--- a/Emitron/Emitron/UI/Library/Filtering/FiltersHeaderView.swift
+++ b/Emitron/Emitron/UI/Library/Filtering/FiltersHeaderView.swift
@@ -50,13 +50,13 @@ struct FiltersHeaderView: View {
         isExpanded.toggle()
       }) {
         HStack {
-          Text(filterGroup.type.name)
+          Text("\(filterGroup.type.name)\(filterCount)")
             .foregroundColor(.titleText)
             .font(.uiLabelBold)
           
           Spacer()
-          
-          Text(isExpanded ? "Hide (\(numOfOnFilters))" : "Show (\(numOfOnFilters))")
+
+          Image(systemName: isExpanded ? "chevron.up" : "chevron.down")
             .foregroundColor(.contentText)
             .font(.uiLabelBold)
         }
@@ -72,11 +72,18 @@ struct FiltersHeaderView: View {
       }
     }
   }
-  
+
+  private var filterCount: String {
+    if numOfOnFilters > 0 {
+      return "・\(numOfOnFilters)"
+    }
+    return ""
+  }
+
   private var numOfOnFilters: Int {
     filterGroup.filters.filter(\.isOn).count
   }
-  
+
   private var expandedView: some View {
     VStack(alignment: .leading, spacing: 8) {
       ForEach(Array(filterGroup.filters), id: \.self) { filter in


### PR DESCRIPTION
The filter design was a little confusing per Luke's enhancement request. I've updated the filter's view to use Luke's recommendation. 

Old view:

![IMG_0174](https://user-images.githubusercontent.com/973751/97357009-7e0ab700-186f-11eb-8508-9605af48d10f.png)

New view:

![IMG_0172](https://user-images.githubusercontent.com/973751/97357134-adb9bf00-186f-11eb-9369-a0e11227bdb4.png)
