### PR TITLE
Change subscription filter fix to be specific per request

### DIFF
--- a/Emitron/Emitron/Models/ContentSubscriptionPlan.swift
+++ b/Emitron/Emitron/Models/ContentSubscriptionPlan.swift
@@ -37,9 +37,9 @@ enum ContentSubscriptionPlan: Int, Codable {
   var displayString: String {
     switch self {
     case .beginner:
-      return "Beginner"
+      return "Beginner Subscription"
     case .professional:
-      return "Professional"
+      return "Professional Subscription"
     }
   }
   


### PR DESCRIPTION
This adds the word "subscription" after the membership level. Here is the old version:

![Screenshot 2020-10-27 at 4 39 02 PM](https://user-images.githubusercontent.com/973751/97481385-1f0a7800-192b-11eb-84c0-d31806b876cc.png)

Here's the updated version:

![Screenshot 2020-10-27 at 4 37 44 PM](https://user-images.githubusercontent.com/973751/97481403-292c7680-192b-11eb-8f20-f9399daeb86b.png)


