### PR TITLE
Add Spacer()'s to vertically centered Illustration

### DIFF
--- a/Emitron/Emitron/UI/App Root/LoginView.swift
+++ b/Emitron/Emitron/UI/App Root/LoginView.swift
@@ -41,6 +41,7 @@ struct LoginView: View {
       
       PagerView(pageCount: 2, showIndicator: true) {
         VStack {
+          Spacer()
           Image("welcomeArtwork1")
             .resizable()
             .aspectRatio(contentMode: .fit)
@@ -57,6 +58,7 @@ struct LoginView: View {
             .font(.uiLabel)
             .foregroundColor(.contentText)
             .multilineTextAlignment(.center)
+          Spacer()
         }
         .background(Color.backgroundColor)
         


### PR DESCRIPTION
This fixes Welcome: Illustration vertical alignment issue #518
By placing two Spacer()'s at the top and the bottom of the VStack

<!-- 🚀 Thank you for contributing! -->

<!-- Describe your changes clearly and use examples if possible. -->

<!-- If this PR fixes an issue, then please link to that issue. If the PR
  is large (or likely to be), it would be prudent to open a discussion in
  advance of the PR to avoid doing large amounts of work that might not
  get merged. -->

<!-- When this PR is merged, a new version of emitron will be pushed to Testflight automatically -->
