### PR TITLE
update SwiftLint workflow to match readme & Fix's Swiftlint warnings for version 0.41.0

### DIFF
--- a/.github/workflows/swiftlint.yml
+++ b/.github/workflows/swiftlint.yml
@@ -9,10 +9,13 @@ on:
 
 jobs:
   SwiftLint:
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v1
-      - name: GitHub Action for SwiftLint
-        uses: norio-nomura/action-swiftlint@3.1.0
+      - name: Install Swiftlint
+        run: brew install swiftlint
+
+      - name: Run Swiftlint
+        run: swiftlint
         with:
           args: --config Emitron/.swiftlint.yml

--- a/.github/workflows/swiftlint.yml
+++ b/.github/workflows/swiftlint.yml
@@ -16,6 +16,4 @@ jobs:
         run: brew install swiftlint
 
       - name: Run Swiftlint
-        run: swiftlint
-        with:
-          args: --config Emitron/.swiftlint.yml
+        run: swiftlint --config Emitron/.swiftlint.yml

--- a/Emitron/Emitron/Constants.swift
+++ b/Emitron/Emitron/Constants.swift
@@ -46,7 +46,7 @@ extension String {
   static let library = "Library"
   static let loading = "Loading…"
   static let myTutorials = "My Tutorials"
-  static let newest =  "Newest"
+  static let newest = "Newest"
   static let popularity = "Popularity"
   static let resetFilters = "Reset Filters"
   static let search = "Search…"

--- a/Emitron/Emitron/Downloads/DownloadService.swift
+++ b/Emitron/Emitron/Downloads/DownloadService.swift
@@ -555,7 +555,7 @@ extension DownloadService {
 extension DownloadService {
   private func configureWifiObservation() {
     // Track the network status
-    networkMonitor.pathUpdateHandler = { [weak self] path in
+    networkMonitor.pathUpdateHandler = { [weak self] _ in
       self?.checkQueueStatus()
     }
     networkMonitor.start(queue: DispatchQueue.global(qos: .utility))

--- a/Emitron/Emitron/Networking/JSONAPI/JSONAPIDocument.swift
+++ b/Emitron/Emitron/Networking/JSONAPI/JSONAPIDocument.swift
@@ -33,7 +33,7 @@ class JSONAPIDocument {
   // MARK: - Properties
   var meta: [String: Any] = [:]
   var included: [JSONAPIResource] = []
-  var data: [JSONAPIResource] =  []
+  var data: [JSONAPIResource] = []
   var errors: [JSONAPIError] = []
   var links: [String: URL] = [:]
 

--- a/Emitron/Emitron/Networking/JSONAPI/JSONAPIRelationship.swift
+++ b/Emitron/Emitron/Networking/JSONAPI/JSONAPIRelationship.swift
@@ -32,7 +32,7 @@ import SwiftyJSON
 public class JSONAPIRelationship {
   // MARK: - Properties
   var meta: [String: Any] = [:]
-  var data: [JSONAPIResource] =  []
+  var data: [JSONAPIResource] = []
   var links: [String: URL] = [:]
   var type: String = ""
 

--- a/Emitron/Emitron/Networking/Requests/Parameters.swift
+++ b/Emitron/Emitron/Networking/Requests/Parameters.swift
@@ -206,7 +206,7 @@ enum Param {
   
   static func sort(for value: ParameterSortValue,
                    descending: Bool) -> Parameter {
-    let key =  "sort"
+    let key = "sort"
     let value = "\(descending ? "-" : "")\(value.rawValue)"
     
     return Parameter(key: key, value: value, displayName: "Sort", sortOrdinal: 0)

--- a/Emitron/emitronScreenshots/SnapshotHelper.swift
+++ b/Emitron/emitronScreenshots/SnapshotHelper.swift
@@ -238,7 +238,7 @@ open class Snapshot: NSObject {
 
 private extension XCUIElementAttributes {
   var isNetworkLoadingIndicator: Bool {
-    if hasWhiteListedIdentifier {
+    if hasAllowedIdentifier {
       return false
     }
     
@@ -248,10 +248,10 @@ private extension XCUIElementAttributes {
     return hasOldLoadingIndicatorSize || hasNewLoadingIndicatorSize
   }
   
-  var hasWhiteListedIdentifier: Bool {
-    let whiteListedIdentifiers = ["GeofenceLocationTrackingOn", "StandardLocationTrackingOn"]
+  var hasAllowedIdentifier: Bool {
+    let allowedIdentifiers = ["GeofenceLocationTrackingOn", "StandardLocationTrackingOn"]
     
-    return whiteListedIdentifiers.contains(identifier)
+    return allowedIdentifiers.contains(identifier)
   }
   
   func isStatusBar(_ deviceWidth: CGFloat) -> Bool {


### PR DESCRIPTION
Updated the SwiftLint workflow to match readme and build process used 
SwiftLint is installed by brew on macos-latest then run with swiftlint --config Emitron/.swiftlint.ym

These changes will fix the following swiftlint warnings for version 0.41.0

- Inclusive Language Violation: Declaration hasWhiteListedIdentifier contains the term "whitelist" which is not considered inclusive. (inclusive_language)

1. SnapshotHelper.swift:251:7
2. SnapshotHelper.swift:252:9

- Operator Usage Whitespace Violation: Operators should be surrounded by a single whitespace when they are being used. (operator_usage_whitespace)

1. Constants.swift:49:20
2. JSONAPIRelationship.swift:35:30
3. JSONAPIDocument.swift:36:30
4. Parameters.swift:209:12

-  Unused Closure Parameter Violation: Unused parameter "path" in a closure should be replaced with _. (unused_closure_parameter) 

1. DownloadService.swift:558:54

<!-- 🚀 Thank you for contributing! -->

<!-- Describe your changes clearly and use examples if possible. -->

<!-- If this PR fixes an issue, then please link to that issue. If the PR
  is large (or likely to be), it would be prudent to open a discussion in
  advance of the PR to avoid doing large amounts of work that might not
  get merged. -->

<!-- When this PR is merged, a new version of emitron will be pushed to Testflight automatically -->
