### PR TITLE
Updating guardpost with the retrieved permissions

### DIFF
--- a/Emitron/Emitron/Sessions/SessionController.swift
+++ b/Emitron/Emitron/Sessions/SessionController.swift
@@ -196,7 +196,7 @@ class SessionController: NSObject, UserModelController, ObservablePrePostFactoOb
           // Update the user
           self.user = user.with(permissions: permissions)
           // Ensure guardpost is aware, and hence the keychain is updated
-          self.guardpost.updateUser(with: user)
+          self.guardpost.updateUser(with: self.user)
         }
       }
     }


### PR DESCRIPTION
Guardpost was not aware of user permission hence calling destroyDownloads() function.
This would remove all downloaded video's
This fixes the issue #506

<!-- 🚀 Thank you for contributing! -->

<!-- Describe your changes clearly and use examples if possible. -->

<!-- If this PR fixes an issue, then please link to that issue. If the PR
  is large (or likely to be), it would be prudent to open a discussion in
  advance of the PR to avoid doing large amounts of work that might not
  get merged. -->

<!-- When this PR is merged, a new version of emitron will be pushed to Testflight automatically -->
