### PR TITLE
Fix conform type to 'Hashable' Warning

### DIFF
--- a/Emitron/Emitron/Models/Attachment.swift
+++ b/Emitron/Emitron/Models/Attachment.swift
@@ -81,6 +81,7 @@ struct Attachment: Codable {
       [.sdVideoFile, .hdVideoFile]
     }
     
+    // Added hash(into: ) funciton because of this bug: https://bugs.swift.org/browse/SR-13851
     func hash(into hasher: inout Hasher) {
       hasher.combine(display)
     }

--- a/Emitron/Emitron/Models/Attachment.swift
+++ b/Emitron/Emitron/Models/Attachment.swift
@@ -80,6 +80,10 @@ struct Attachment: Codable {
     static var selectableCases: [Attachment.Kind] {
       [.sdVideoFile, .hdVideoFile]
     }
+    
+    func hash(into hasher: inout Hasher) {
+      hasher.combine(display)
+    }
   }
   
   var id: Int

--- a/Emitron/Emitron/Models/PlaybackSpeed.swift
+++ b/Emitron/Emitron/Models/PlaybackSpeed.swift
@@ -70,6 +70,6 @@ enum PlaybackSpeed: Int, CaseIterable, SettingsSelectable {
 extension PlaybackSpeed {
   // Added hash(into: ) funciton because of this bug: https://bugs.swift.org/browse/SR-13851
   func hash(into hasher: inout Hasher) {
-    hasher.combine(rate)
+    hasher.combine(display)
   }
 }

--- a/Emitron/Emitron/Models/PlaybackSpeed.swift
+++ b/Emitron/Emitron/Models/PlaybackSpeed.swift
@@ -68,6 +68,7 @@ enum PlaybackSpeed: Int, CaseIterable, SettingsSelectable {
 }
 
 extension PlaybackSpeed {
+  // Added hash(into: ) funciton because of this bug: https://bugs.swift.org/browse/SR-13851
   func hash(into hasher: inout Hasher) {
     hasher.combine(rate)
   }

--- a/Emitron/Emitron/Models/PlaybackSpeed.swift
+++ b/Emitron/Emitron/Models/PlaybackSpeed.swift
@@ -66,3 +66,9 @@ enum PlaybackSpeed: Int, CaseIterable, SettingsSelectable {
     allCases
   }
 }
+
+extension PlaybackSpeed {
+  func hash(into hasher: inout Hasher) {
+    hasher.combine(rate)
+  }
+}


### PR DESCRIPTION
<!-- 🚀 Thank you for contributing! -->

<!-- Describe your changes clearly and use examples if possible. -->
These changes fix the following swift compiler warning's every time the project is built. 

```
/Swift.RawRepresentable:2:27: 'Hashable.hashValue' is deprecated as a protocol requirement; conform type 'PlaybackSpeed' to 'Hashable' by implementing 'hash(into:)' instead
/Swift.RawRepresentable:2:27: 'Hashable.hashValue' is deprecated as a protocol requirement; conform type 'Attachment.Kind' to 'Hashable' by implementing 'hash(into:)' instead
```

<!-- If this PR fixes an issue, then please link to that issue. If the PR
  is large (or likely to be), it would be prudent to open a discussion in
  advance of the PR to avoid doing large amounts of work that might not
  get merged. -->

<!-- When this PR is merged, a new version of emitron will be pushed to Testflight automatically -->
