### PR TITLE
Removed Padding causing too much authors vertical spacing

### DIFF
--- a/Emitron/Emitron/UI/Shared/Content Detail/ContentDetailView.swift
+++ b/Emitron/Emitron/UI/Shared/Content Detail/ContentDetailView.swift
@@ -75,7 +75,6 @@ private extension ContentDetailView {
           
           ContentSummaryView(content: content, dynamicContentViewModel: dynamicContentViewModel)
             .padding([.leading, .trailing], 20)
-            .padding(.bottom, 37)
         }
         .listRowInsets(EdgeInsets())
         .listRowBackground(Color.backgroundColor)

--- a/Emitron/Emitron/UI/Shared/Content Detail/ContentSummaryView.swift
+++ b/Emitron/Emitron/UI/Shared/Content Detail/ContentSummaryView.swift
@@ -104,7 +104,6 @@ extension ContentSummaryView: View {
         .font(.uiCaption)
         .foregroundColor(.contentText)
         .lineLimit(2)
-        .padding(.top, 10)
         .lineSpacing(3)
     }
   }


### PR DESCRIPTION
Removed Padding causing vertical space issue on authors information reported in #522

![image](https://user-images.githubusercontent.com/4116539/101276541-5a178b00-37b6-11eb-9e52-f5ab8d7ac7f5.png)
