### PR TITLE
Titles, subtitles and episode titles need kerning by -0.5

### DIFF
--- a/Emitron/Emitron/UI/Shared/Content Detail/ChildContentListingView.swift
+++ b/Emitron/Emitron/UI/Shared/Content Detail/ChildContentListingView.swift
@@ -58,6 +58,7 @@ private extension ChildContentListingView {
         if childContentsViewModel.contents.count > 1 {
           Text("Course Episodes")
             .font(.uiTitle2)
+            .kerning(-0.5)
             .foregroundColor(.titleText)
             .padding([.top, .bottom])
         }

--- a/Emitron/Emitron/UI/Shared/Content Detail/ContentSummaryView.swift
+++ b/Emitron/Emitron/UI/Shared/Content Detail/ContentSummaryView.swift
@@ -69,6 +69,7 @@ extension ContentSummaryView: View {
       
       Text(content.name)
         .font(.uiTitle1)
+        .kerning(-0.5)
         .lineLimit(nil)
         .padding([.top], 10)
         .foregroundColor(.titleText)

--- a/Emitron/Emitron/UI/Shared/Content Detail/CourseHeaderView.swift
+++ b/Emitron/Emitron/UI/Shared/Content Detail/CourseHeaderView.swift
@@ -37,6 +37,7 @@ struct CourseHeaderView: View {
       HStack {
         Text(name)
           .font(.uiTitle3)
+          .kerning(-0.5)
           .foregroundColor(.titleText)
           .padding(.leading, 20)
         Spacer()

--- a/Emitron/Emitron/UI/Shared/Content Detail/TextListItemView.swift
+++ b/Emitron/Emitron/UI/Shared/Content Detail/TextListItemView.swift
@@ -57,6 +57,7 @@ struct TextListItemView: View {
           VStack(alignment: .leading, spacing: 5) {
             Text(content.name)
               .font(.uiTitle5)
+              .kerning(-0.5)
               .lineSpacing(3)
               .foregroundColor(.titleText)
             


### PR DESCRIPTION
Added kern of -0.5 to the title "Course episodes", section titles of and title of each episode 
The spacing issue that required the kerning reported in issue #523 and #520

See title before and after adding the kerning() modifiers.

![image](https://user-images.githubusercontent.com/4116539/101304052-1a997f00-3848-11eb-82de-61aca7573b97.png)
