### PR TITLE
Make debugging easier, Login Once

### DIFF
--- a/Emitron/Emitron/Guardpost/Guardpost.swift
+++ b/Emitron/Emitron/Guardpost/Guardpost.swift
@@ -127,7 +127,10 @@ public class Guardpost {
     authSession?.presentationContextProvider = presentationContextDelegate
     // This will prevent sharing cookies with Safari, which means no auto-login
     // However, it also means that you can actually log out, which is good, I guess.
+    #if (!DEBUG)
     authSession?.prefersEphemeralWebBrowserSession = true
+    #endif
+    
     authSession?.start()
   }
 


### PR DESCRIPTION
Make debugging easier Removes the need to enter login details every time you build and run the app. 
The first time you build and run, you might still have to enter your email and password, but in subsequent build and runs, tapping Continue skips the login form.

This also removes the need to add the note below in Raywenderlich courses that use this App as a Demo App.
The note below was added to [Getting Started With Widgets](https://www.raywenderlich.com/11303363-getting-started-with-widgets)

<img width="750" alt="Screenshot 2020-12-09 at 07 19 11" src="https://user-images.githubusercontent.com/4116539/101588532-4dca4280-39ef-11eb-88a3-9d96e557e30b.png">

