### PR TITLE
Fix padding & kerning for Design +  Fix Strange Animation issue.

### DIFF
--- a/Emitron/Emitron/UI/Shared/Content Detail/ChildContentListingView.swift
+++ b/Emitron/Emitron/UI/Shared/Content Detail/ChildContentListingView.swift
@@ -58,6 +58,7 @@ private extension ChildContentListingView {
         if childContentsViewModel.contents.count > 1 {
           Text("Course Episodes")
             .font(.uiTitle2)
+            .kerning(-0.5)
             .foregroundColor(.titleText)
             .padding([.top, .bottom])
         }

--- a/Emitron/Emitron/UI/Shared/Content Detail/ChildContentListingView.swift
+++ b/Emitron/Emitron/UI/Shared/Content Detail/ChildContentListingView.swift
@@ -59,15 +59,15 @@ private extension ChildContentListingView {
           HStack {
             Text("Course Episodes")
               .font(.uiTitle2)
-            .kerning(-0.5)
+              .kerning(-0.5)
               .foregroundColor(.titleText)
               .padding([.top, .bottom])
             Spacer()
           }.padding([.leading, .trailing], 20)
         }
       }
-        .listRowBackground(Color.backgroundColor)
-        .accessibility(identifier: "childContentList")
+      .listRowBackground(Color.backgroundColor)
+      .accessibility(identifier: "childContentList")
         
       if childContentsViewModel.groups.count > 1 {
         ForEach(childContentsViewModel.groups, id: \.id) { group in

--- a/Emitron/Emitron/UI/Shared/Content Detail/ChildContentListingView.swift
+++ b/Emitron/Emitron/UI/Shared/Content Detail/ChildContentListingView.swift
@@ -56,10 +56,13 @@ private extension ChildContentListingView {
     SwiftUI.Group {
       Section {
         if childContentsViewModel.contents.count > 1 {
-          Text("Course Episodes")
-            .font(.uiTitle2)
-            .foregroundColor(.titleText)
-            .padding([.top, .bottom])
+          HStack {
+            Text("Course Episodes")
+              .font(.uiTitle2)
+              .foregroundColor(.titleText)
+              .padding([.top, .bottom])
+            Spacer()
+          }.padding([.leading, .trailing], 20)
         }
       }
         .listRowBackground(Color.backgroundColor)

--- a/Emitron/Emitron/UI/Shared/Content Detail/ContentDetailView.swift
+++ b/Emitron/Emitron/UI/Shared/Content Detail/ContentDetailView.swift
@@ -76,6 +76,7 @@ private extension ContentDetailView {
           ContentSummaryView(content: content, dynamicContentViewModel: dynamicContentViewModel)
             .padding([.leading, .trailing], 20)
             .padding(.bottom, 37)
+            .background(Color.backgroundColor)
         }
         .listRowInsets(EdgeInsets())
         .listRowBackground(Color.backgroundColor)

--- a/Emitron/Emitron/UI/Shared/Content Detail/ContentDetailView.swift
+++ b/Emitron/Emitron/UI/Shared/Content Detail/ContentDetailView.swift
@@ -65,8 +65,8 @@ extension ContentDetailView: View {
 private extension ContentDetailView {
   var contentView: some View {
     GeometryReader { geometry in
-      List {
-        Section {
+      ScrollView {
+        VStack {
           if content.professional && !canStreamPro {
             headerImageLockedProContent(for: geometry.size.width)
           } else {
@@ -76,19 +76,17 @@ private extension ContentDetailView {
           ContentSummaryView(content: content, dynamicContentViewModel: dynamicContentViewModel)
             .padding([.leading, .trailing], 20)
             .background(Color.backgroundColor)
-        }
-        .listRowInsets(EdgeInsets())
-        .listRowBackground(Color.backgroundColor)
-        
-        ChildContentListingView(
-          childContentsViewModel: childContentsViewModel,
-          currentlyDisplayedVideoPlaybackViewModel: $currentlyDisplayedVideoPlaybackViewModel
-        )
+          
+          ChildContentListingView(
+            childContentsViewModel: childContentsViewModel,
+            currentlyDisplayedVideoPlaybackViewModel: $currentlyDisplayedVideoPlaybackViewModel
+          )
           .background(Color.backgroundColor)
+        }
       }
     }
-      .navigationBarTitle(Text(""), displayMode: .inline)
-      .background(Color.backgroundColor)
+    .navigationBarTitle(Text(""), displayMode: .inline)
+    .background(Color.backgroundColor)
   }
 
   var canStreamPro: Bool { user.canStreamPro }

--- a/Emitron/Emitron/UI/Shared/Content Detail/ContentDetailView.swift
+++ b/Emitron/Emitron/UI/Shared/Content Detail/ContentDetailView.swift
@@ -75,7 +75,6 @@ private extension ContentDetailView {
           
           ContentSummaryView(content: content, dynamicContentViewModel: dynamicContentViewModel)
             .padding([.leading, .trailing], 20)
-            .padding(.bottom, 37)
         }
         .listRowInsets(EdgeInsets())
         .listRowBackground(Color.backgroundColor)

--- a/Emitron/Emitron/UI/Shared/Content Detail/ContentSummaryView.swift
+++ b/Emitron/Emitron/UI/Shared/Content Detail/ContentSummaryView.swift
@@ -69,6 +69,7 @@ extension ContentSummaryView: View {
       
       Text(content.name)
         .font(.uiTitle1)
+        .kerning(-0.5)
         .lineLimit(nil)
         .padding([.top], 10)
         .foregroundColor(.titleText)

--- a/Emitron/Emitron/UI/Shared/Content Detail/ContentSummaryView.swift
+++ b/Emitron/Emitron/UI/Shared/Content Detail/ContentSummaryView.swift
@@ -70,12 +70,14 @@ extension ContentSummaryView: View {
       Text(content.name)
         .font(.uiTitle1)
         .lineLimit(nil)
+        .fixedSize(horizontal: false, vertical: true)
         .foregroundColor(.titleText)
       
       Text(content.contentSummaryMetadataString)
         .font(.uiCaption)
         .foregroundColor(.contentText)
         .lineSpacing(3)
+        .fixedSize(horizontal: false, vertical: true)
       
       HStack(spacing: 30, content: {
         if canDownload {
@@ -97,6 +99,7 @@ extension ContentSummaryView: View {
         .lineSpacing(3)
         .padding(.top, 15)
         .lineLimit(nil)
+        .fixedSize(horizontal: false, vertical: true)
       
       Text("By \(content.contributorString)")
         .font(.uiCaption)
@@ -104,6 +107,7 @@ extension ContentSummaryView: View {
         .lineLimit(2)
         .padding(.top, 10)
         .lineSpacing(3)
+        .fixedSize(horizontal: false, vertical: true)
     }
   }
 }

--- a/Emitron/Emitron/UI/Shared/Content Detail/ContentSummaryView.swift
+++ b/Emitron/Emitron/UI/Shared/Content Detail/ContentSummaryView.swift
@@ -70,14 +70,12 @@ extension ContentSummaryView: View {
       Text(content.name)
         .font(.uiTitle1)
         .lineLimit(nil)
-        .padding([.top], 10)
         .foregroundColor(.titleText)
       
       Text(content.contentSummaryMetadataString)
         .font(.uiCaption)
         .foregroundColor(.contentText)
         .lineSpacing(3)
-        .padding([.top], 10)
       
       HStack(spacing: 30, content: {
         if canDownload {

--- a/Emitron/Emitron/UI/Shared/Content Detail/ContentSummaryView.swift
+++ b/Emitron/Emitron/UI/Shared/Content Detail/ContentSummaryView.swift
@@ -104,7 +104,6 @@ extension ContentSummaryView: View {
         .font(.uiCaption)
         .foregroundColor(.contentText)
         .lineLimit(2)
-        .padding(.top, 10)
         .lineSpacing(3)
     }
   }

--- a/Emitron/Emitron/UI/Shared/Content Detail/CourseHeaderView.swift
+++ b/Emitron/Emitron/UI/Shared/Content Detail/CourseHeaderView.swift
@@ -37,6 +37,7 @@ struct CourseHeaderView: View {
       HStack {
         Text(name)
           .font(.uiTitle3)
+          .kerning(-0.5)
           .foregroundColor(.titleText)
           .padding(.leading, 20)
         Spacer()

--- a/Emitron/Emitron/UI/Shared/Content Detail/TextListItemView.swift
+++ b/Emitron/Emitron/UI/Shared/Content Detail/TextListItemView.swift
@@ -57,6 +57,7 @@ struct TextListItemView: View {
           VStack(alignment: .leading, spacing: 5) {
             Text(content.name)
               .font(.uiTitle5)
+              .kerning(-0.5)
               .lineSpacing(3)
               .foregroundColor(.titleText)
             


### PR DESCRIPTION
Replaced List with ScrollView remove the strange animations reported in #469 & #486
Which are seen when downloading any video course that has numerous episodes.

With the change to ScrollView  `.fixedSize(horizontal: false, vertical: true)`  had to be added to a number of Text-Views so the Text-Views could take all the vertical Space it needs. 

Removed Padding causing vertical space issue on title and date reported in #517 
Removed Padding causing vertical space issue on authors information reported in #522

Added kern of -0.5 to the title "Course episodes", section titles of and title of each episode 
The spacing issue that required the kerning reported in issue #523 and #520

See title before and after adding the kerning() modifiers.

![image](https://user-images.githubusercontent.com/4116539/101304052-1a997f00-3848-11eb-82de-61aca7573b97.png)


see image below for before and after. 
![Group](https://user-images.githubusercontent.com/4116539/101679758-6dea1800-3a68-11eb-86f8-c7819706865c.jpg)
![image](https://user-images.githubusercontent.com/4116539/101276541-5a178b00-37b6-11eb-9e52-f5ab8d7ac7f5.png)
