### PR TITLE
555-Add support for 0.75x and 1.25x playback speeds

### DIFF
--- a/Emitron/Emitron/Models/PlaybackSpeed.swift
+++ b/Emitron/Emitron/Models/PlaybackSpeed.swift
@@ -28,7 +28,9 @@
 
 enum PlaybackSpeed: Int, CaseIterable, SettingsSelectable {
   case half
+  case threeQuarters
   case standard
+  case onePointTwoFive
   case onePointFive
   case double
   
@@ -40,8 +42,12 @@ enum PlaybackSpeed: Int, CaseIterable, SettingsSelectable {
     switch self {
     case .half:
       return 0.5
+    case .threeQuarters:
+      return 0.75
     case .standard:
       return 1.0
+    case .onePointTwoFive:
+      return 1.25
     case .onePointFive:
       return 1.5
     case .double:
@@ -53,8 +59,12 @@ enum PlaybackSpeed: Int, CaseIterable, SettingsSelectable {
     switch self {
     case .half:
       return "0.5x"
+    case .threeQuarters:
+      return "0.75x"
     case .standard:
       return "1.0x"
+    case .onePointTwoFive:
+      return "1.25x"
     case .onePointFive:
       return "1.5x"
     case .double:

--- a/Emitron/emitronTests/Settings/SettingsManagerTest.swift
+++ b/Emitron/emitronTests/Settings/SettingsManagerTest.swift
@@ -114,10 +114,13 @@ class SettingsManagerTest: XCTestCase {
     settingsManager.playbackSpeed = .double
     settingsManager.playbackSpeed = .standard
     settingsManager.playbackSpeed = .onePointFive
+    settingsManager.playbackSpeed = .half
+    settingsManager.playbackSpeed = .threeQuarters
+    settingsManager.playbackSpeed = .onePointTwoFive
     
-    let stream = try wait(for: recorder.next(3), timeout: 5)
+    let stream = try wait(for: recorder.next(6), timeout: 5)
     
-    XCTAssertEqual([.double, .standard, .onePointFive], stream)
+    XCTAssertEqual([.double, .standard, .onePointFive, .half, .threeQuarters, .onePointTwoFive], stream)
   }
   
   func testClosedCaptionOnSuccessfullyPersisted() {


### PR DESCRIPTION
This commit adds new 0.75x and 1.25x playback speeds to the 'Settings' screen, to align the rates supported by the app with those available online.

See related github issue #555.

![image](https://user-images.githubusercontent.com/3955360/112216014-f1df9e80-8c18-11eb-861b-fba3792477f2.png)

![image](https://user-images.githubusercontent.com/3955360/112216038-f7d57f80-8c18-11eb-8780-917829d21c6b.png)
