### PR TITLE
Fix failing 'Swiftlint' and 'Run Tests' Github Actions workflows

### DIFF
--- a/.github/workflows/swiftlint.yml
+++ b/.github/workflows/swiftlint.yml
@@ -12,8 +12,6 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v1
-      - name: Install Swiftlint
-        run: brew install swiftlint
 
       - name: Run Swiftlint
         run: swiftlint --config Emitron/.swiftlint.yml

--- a/Emitron/emitronTests/Downloads/DownloadQueueManagerTest.swift
+++ b/Emitron/emitronTests/Downloads/DownloadQueueManagerTest.swift
@@ -107,7 +107,7 @@ class DownloadQueueManagerTest: XCTestCase {
     }
     .record()
     
-    let completion = try wait(for: recorder.completion, timeout: 5)
+    let completion = try wait(for: recorder.completion, timeout: 10)
     
     XCTAssert(completion == .finished)
     

--- a/Emitron/emitronTests/Downloads/DownloadServiceTest.swift
+++ b/Emitron/emitronTests/Downloads/DownloadServiceTest.swift
@@ -86,7 +86,7 @@ class DownloadServiceTest: XCTestCase {
     }
     .record()
     
-    let completion = try wait(for: recorder.completion, timeout: 5)
+    let completion = try wait(for: recorder.completion, timeout: 10)
     XCTAssert(completion == .finished)
     
     let download = getAllDownloads().first!
@@ -206,7 +206,7 @@ class DownloadServiceTest: XCTestCase {
     }
     .record()
     
-    let completion = try wait(for: recorder.completion, timeout: 5)
+    let completion = try wait(for: recorder.completion, timeout: 10)
     XCTAssert(completion == .finished)
     
     let allContentIds = fullState.childContents.map(\.id) + [collection.0.id]
@@ -330,7 +330,7 @@ class DownloadServiceTest: XCTestCase {
     }
     .record()
     
-    let completion = try wait(for: recorder2.completion, timeout: 5)
+    let completion = try wait(for: recorder2.completion, timeout: 10)
     XCTAssert(completion == .finished)
     
     // Added the correct number of models
@@ -354,7 +354,7 @@ class DownloadServiceTest: XCTestCase {
     }
     .record()
     
-    let completion = try wait(for: recorder.completion, timeout: 5)
+    let completion = try wait(for: recorder.completion, timeout: 10)
     XCTAssert(completion == .finished)
     
     XCTAssertEqual(2, getAllDownloads().count)
@@ -381,9 +381,9 @@ class DownloadServiceTest: XCTestCase {
     }
     .record()
     
-    _ = try wait(for: recorder1.completion, timeout: 5)
-    _ = try wait(for: recorder2.completion, timeout: 5)
-    _ = try wait(for: recorder3.completion, timeout: 5)
+    _ = try wait(for: recorder1.completion, timeout: 10)
+    _ = try wait(for: recorder2.completion, timeout: 10)
+    _ = try wait(for: recorder3.completion, timeout: 10)
     
     XCTAssertEqual(4, getAllDownloads().count)
   }

--- a/Emitron/emitronTests/Persistence/PersistenceStore+DownloadsTest.swift
+++ b/Emitron/emitronTests/Persistence/PersistenceStore+DownloadsTest.swift
@@ -67,7 +67,7 @@ class PersistenceStore_DownloadsTest: XCTestCase {
     }
     .record()
     
-    _ = try wait(for: recorder.completion, timeout: 5)
+    _ = try wait(for: recorder.completion, timeout: 10)
     
     return screencast.0
   }
@@ -80,7 +80,7 @@ class PersistenceStore_DownloadsTest: XCTestCase {
     }
     .record()
     
-    _ = try wait(for: recorder.completion, timeout: 5)
+    _ = try wait(for: recorder.completion, timeout: 10)
     
     return collection.0
   }


### PR DESCRIPTION
The 'SwiftLint' workflow is currently failing in GitHub Actions, with the the following error:

```
Error: The `brew link` step did not complete successfully
The formula built, but is not symlinked into /usr/local
Could not symlink bin/swiftlint
Target /usr/local/bin/swiftlint
already exists. You may want to remove it:
  rm '/usr/local/bin/swiftlint'

To force the link and overwrite all conflicting files:
  brew link --overwrite swiftlint

To list all files that would be deleted:
  brew link --overwrite --dry-run swiftlint

Possible conflicting files are:
/usr/local/bin/swiftlint
==> Summary
🍺  /usr/local/Cellar/swiftlint/0.43.0: 6 files, 13.4MB
Error: Process completed with exit code 1.
```

The exit code of '1' then causes the workflow to fail.

The root cause of this failure is that, from [`macos-10.14`](https://github.com/actions/virtual-environments/blob/main/images/macos/macos-10.14-Readme.md) onwards, SwiftLint is installed in the base image used by 
the workflow.  Attempting to install SwiftLint using `brew` then causes the errors seen above.

This PR simply removes the 'Install SwiftLint' step, so that we just rely on the underlying version of SwiftLint installed on the base image.

[Edit]: In addition, this PR adjusts some of the expectation wait timeouts, to correct additional failing tests in the 'Run tests' workflow.