### PR TITLE
Fix some lint warnings

### DIFF
--- a/Emitron/Emitron/Data/ViewModels/DynamicContentViewModel.swift
+++ b/Emitron/Emitron/Data/ViewModels/DynamicContentViewModel.swift
@@ -40,7 +40,7 @@ final class DynamicContentViewModel: ObservableObject, DynamicContentDisplayable
   var state: DataState = .initial
   @Published var viewProgress: ContentViewProgressDisplayable = .notStarted
   @Published var downloadProgress: DownloadProgressDisplayable = .notDownloadable
-  @Published var bookmarked: Bool = false
+  @Published var bookmarked = false
   
   private var subscriptions = Set<AnyCancellable>()
   private var downloadActionSubscriptions = Set<AnyCancellable>()

--- a/Emitron/Emitron/Data/ViewModels/VideoPlaybackViewModel.swift
+++ b/Emitron/Emitron/Data/ViewModels/VideoPlaybackViewModel.swift
@@ -74,7 +74,7 @@ extension VideoPlaybackViewModel {
 
 final class VideoPlaybackViewModel {
   // Allow control of appearance and dismissal of the video view
-  var shouldShow: Bool = false
+  var shouldShow = false
   
   private let initialContentId: Int
   private let repository: Repository

--- a/Emitron/Emitron/Downloads/DownloadProcessor.swift
+++ b/Emitron/Emitron/Downloads/DownloadProcessor.swift
@@ -69,7 +69,7 @@ final class DownloadProcessor: NSObject {
     let config = URLSessionConfiguration.background(withIdentifier: DownloadProcessor.sessionIdentifier)
     // Uncommenting this causes the download task to fail with POSIX 22. But seemingly only with
     // Vimeo URLs. So that's handy.
-    //config.isDiscretionary = true
+    // config.isDiscretionary = true
     config.sessionSendsLaunchEvents = true
     return URLSession(configuration: config, delegate: self, delegateQueue: .none)
   }()

--- a/Emitron/Emitron/Networking/Requests/Parameters.swift
+++ b/Emitron/Emitron/Networking/Requests/Parameters.swift
@@ -162,7 +162,7 @@ enum ParameterFilterValue {
   }
 }
 
-//sort=-released_at; reversechronological order
+// sort=-released_at; reversechronological order
 enum ParameterSortValue: String, Codable {
   case popularity = "popularity"
   case releasedAt = "released_at"

--- a/Emitron/Emitron/Persistence/PersistenceStore+Downloads.swift
+++ b/Emitron/Emitron/Persistence/PersistenceStore+Downloads.swift
@@ -337,7 +337,6 @@ extension PersistenceStore {
       }
     }
   }
-
   
   /// Save the entire graph of models to supprt this ContentDeailsModel
   /// - Parameter contentPersistableState: The model to persist—from the DataCache.

--- a/Emitron/Emitron/UI/App Root/PermissionsLoadingView.swift
+++ b/Emitron/Emitron/UI/App Root/PermissionsLoadingView.swift
@@ -30,7 +30,7 @@ import SwiftUI
 
 struct PermissionsLoadingView: View {
   @EnvironmentObject var sessionController: SessionController
-  @State var showLogoutAlert: Bool = false
+  @State var showLogoutAlert = false
   
   var body: some View {
     LoadingView()

--- a/Emitron/Emitron/UI/Library/Filtering/FiltersHeaderView.swift
+++ b/Emitron/Emitron/UI/Library/Filtering/FiltersHeaderView.swift
@@ -42,7 +42,7 @@ struct FiltersHeaderView: View {
   var filterGroup: FilterGroup
   @ObservedObject var filters: Filters
   
-  @State var isExpanded: Bool = false
+  @State var isExpanded = false
   
   var body: some View {
     VStack {

--- a/Emitron/Emitron/UI/Library/LibraryView.swift
+++ b/Emitron/Emitron/UI/Library/LibraryView.swift
@@ -38,7 +38,7 @@ private extension CGFloat {
 struct LibraryView: View {
   @ObservedObject var filters: Filters
   @ObservedObject var libraryRepository: LibraryRepository
-  @State var filtersPresented: Bool = false
+  @State var filtersPresented = false
 
   var body: some View {
     contentView

--- a/Emitron/Emitron/UI/Settings/Licenses/LicenseListView.swift
+++ b/Emitron/Emitron/UI/Settings/Licenses/LicenseListView.swift
@@ -66,7 +66,7 @@ struct LicenseListView: View {
 }
 
 struct LicenseListView_Previews: PreviewProvider {
-  @State static var visible: Bool = true
+  @State static var visible = true
   
   static var previews: some View {
     SwiftUI.Group {

--- a/Emitron/Emitron/UI/Settings/SettingsView.swift
+++ b/Emitron/Emitron/UI/Settings/SettingsView.swift
@@ -38,7 +38,7 @@ struct SettingsView: View {
   @EnvironmentObject var sessionController: SessionController
   @EnvironmentObject var tabViewModel: TabViewModel
   @ObservedObject private var settingsManager = SettingsManager.current
-  @State private var licensesPresented: Bool = false
+  @State private var licensesPresented = false
   
   var body: some View {
       VStack {

--- a/Emitron/Emitron/UI/Shared/CheckmarkView.swift
+++ b/Emitron/Emitron/UI/Shared/CheckmarkView.swift
@@ -28,7 +28,7 @@
 
 import SwiftUI
 
-//TODO: Refactor layout properties here
+// TODO: Refactor layout properties here
 struct CheckmarkView: View {
   var isOn: Bool
   

--- a/Emitron/Emitron/UI/Shared/Content Detail/ChildContentListingView.swift
+++ b/Emitron/Emitron/UI/Shared/Content Detail/ChildContentListingView.swift
@@ -166,8 +166,8 @@ private extension ChildContentListingView {
   }
 }
 
-//struct ChildContentListingView_Previews: PreviewProvider {
+// struct ChildContentListingView_Previews: PreviewProvider {
 //  static var previews: some View {
 //    ChildContentListingView()
 //  }
-//}
+// }

--- a/Emitron/Emitron/UI/Shared/Content Detail/ContentSummaryView.swift
+++ b/Emitron/Emitron/UI/Shared/Content Detail/ContentSummaryView.swift
@@ -130,8 +130,8 @@ private extension ContentSummaryView {
   }
   
   private var bookmarkButton: some View {
-    //ISSUE: Changing this from button to "onTapGesture" because the tap target between the download button and the
-    //bookmark button somehow wasn't... clearly defined, so they'd both get pressed when the bookmark button got pressed
+    // ISSUE: Changing this from button to "onTapGesture" because the tap target between the download button and the
+    // bookmark button somehow wasn't... clearly defined, so they'd both get pressed when the bookmark button got pressed
     Image.bookmark
       .resizable()
       .frame(width: Layout.buttonSize, height: Layout.buttonSize)

--- a/Emitron/Emitron/UI/Shared/Content List/ContentListView.swift
+++ b/Emitron/Emitron/UI/Shared/Content List/ContentListView.swift
@@ -105,7 +105,7 @@ private extension ContentListView {
         
         navLink(for: partialContent)
           .buttonStyle(PlainButtonStyle())
-          //HACK: to remove navigation chevrons
+          // HACK: to remove navigation chevrons
           .padding(.trailing, -2 * .sidePadding)
       }
     }

--- a/Emitron/Emitron/UI/Video/FullScreenVideoPlayerViewController.swift
+++ b/Emitron/Emitron/UI/Video/FullScreenVideoPlayerViewController.swift
@@ -32,7 +32,7 @@ import SwiftUI
 
 class FullScreenVideoPlayerViewController: UIViewController {
   @Binding var viewModel: VideoPlaybackViewModel?
-  private var isFullscreen: Bool = false
+  private var isFullscreen = false
   
   init(viewModel: Binding<VideoPlaybackViewModel?>) {
     _viewModel = viewModel

--- a/Emitron/Emitron/Utilities/MessageBus.swift
+++ b/Emitron/Emitron/Utilities/MessageBus.swift
@@ -36,7 +36,7 @@ struct Message {
   
   let level: Level
   let message: String
-  var autoDismiss: Bool = true
+  var autoDismiss = true
 }
 
 extension Message {
@@ -60,7 +60,7 @@ extension Message.Level {
 
 final class MessageBus: ObservableObject {
   @Published private(set) var currentMessage: Message?
-  @Published var messageVisible: Bool = false
+  @Published var messageVisible = false
   
   private var currentTimer: AnyCancellable?
   

--- a/Emitron/emitronTests/Downloads/DownloadQueueManagerTest.swift
+++ b/Emitron/emitronTests/Downloads/DownloadQueueManagerTest.swift
@@ -167,8 +167,8 @@ class DownloadQueueManagerTest: XCTestCase {
     }
     
     // This shouldn't fire cos it doesn't affect the stream
-    //readyForDownload = try wait(for: recorder.next(), timeout: 5)
-    //XCTAssertEqual(download1, readyForDownload!!.download)
+    // readyForDownload = try wait(for: recorder.next(), timeout: 5)
+    // XCTAssertEqual(download1, readyForDownload!!.download)
     
     try database.write { db in
       download1.state = .enqueued


### PR DESCRIPTION
<!-- 🚀 Thank you for contributing! -->

<!-- Describe your changes clearly and use examples if possible. -->
## Description
When I opened the project inside of Xcode after installing SwiftLint I saw some warnings pop up and I decided to fix the ones that I could understand without much Swift knowledge (I'm pretty new to Swift development).

There's still a couple of warnings in the project about the configured rules, specifically that `unused_private_declaration` isn't something my installation recognizes, and `line_length` is disabled but has a configuration, and I'm not 100% sure what to do with those.

I tried to make the commits fairly self-explanatory and standalone as well.

<!-- If this PR fixes an issue, then please link to that issue. If the PR
  is large (or likely to be), it would be prudent to open a discussion in
  advance of the PR to avoid doing large amounts of work that might not
  get merged. -->

<!-- When this PR is merged, a new version of emitron will be pushed to Testflight automatically -->
