### PR TITLE
Fix spacing and placement issue in the design 

### DIFF
--- a/Emitron/Emitron/UI/Shared/Content Detail/ContentSummaryView.swift
+++ b/Emitron/Emitron/UI/Shared/Content Detail/ContentSummaryView.swift
@@ -37,7 +37,7 @@ struct ContentSummaryView {
   private let content: ContentListDisplayable
   @ObservedObject private var dynamicContentViewModel: DynamicContentViewModel
   @State private var deletionConfirmation: DownloadDeletionConfirmation?
-
+  
   init(
     content: ContentListDisplayable,
     dynamicContentViewModel: DynamicContentViewModel
@@ -73,6 +73,8 @@ extension ContentSummaryView: View {
         .lineLimit(nil)
         .fixedSize(horizontal: false, vertical: true)
         .foregroundColor(.titleText)
+      
+      Spacer()
       
       Text(content.contentSummaryMetadataString)
         .font(.uiCaption)
@@ -121,7 +123,7 @@ private extension ContentSummaryView {
   var canDownload: Bool {
     sessionController.user?.canDownload ?? false
   }
-
+  
   var completedTag: CompletedTag? {
     if case .completed = dynamicContentViewModel.viewProgress {
       return CompletedTag()

--- a/Emitron/Emitron/UI/Shared/Content Detail/TextListItemView.swift
+++ b/Emitron/Emitron/UI/Shared/Content Detail/TextListItemView.swift
@@ -66,18 +66,18 @@ struct TextListItemView: View {
               .font(.uiFootnote)
               .foregroundColor(.contentText)
           }
-            
+          
           Spacer()
-            
+          
           if canDownload {
             VStack {
               Spacer()
-            DownloadIcon(downloadProgress: dynamicContentViewModel.downloadProgress)
-              .onTapGesture {
-                download()
-              }
-              .alert(item: $deletionConfirmation, content: \.alert)
-              .padding(.bottom, 5)
+              DownloadIcon(downloadProgress: dynamicContentViewModel.downloadProgress)
+                .onTapGesture {
+                  download()
+                }
+                .alert(item: $deletionConfirmation, content: \.alert)
+                .padding(.bottom, 5)
               Spacer()
             }
           }

--- a/Emitron/Emitron/UI/Shared/Content Detail/TextListItemView.swift
+++ b/Emitron/Emitron/UI/Shared/Content Detail/TextListItemView.swift
@@ -60,6 +60,7 @@ struct TextListItemView: View {
               .kerning(-0.5)
               .lineSpacing(3)
               .foregroundColor(.titleText)
+              .fixedSize(horizontal: false, vertical: true)
             
             Text(content.duration.minuteSecondTimeFromSeconds)
               .font(.uiFootnote)
@@ -69,11 +70,16 @@ struct TextListItemView: View {
           Spacer()
             
           if canDownload {
+            VStack {
+              Spacer()
             DownloadIcon(downloadProgress: dynamicContentViewModel.downloadProgress)
               .onTapGesture {
                 download()
               }
               .alert(item: $deletionConfirmation, content: \.alert)
+              .padding(.bottom, 5)
+              Spacer()
+            }
           }
         }
         progressBar


### PR DESCRIPTION
<!-- 🚀 Thank you for contributing! -->

<!-- Describe your changes clearly and use examples if possible. -->

<!-- If this PR fixes an issue, then please link to that issue. If the PR
  is large (or likely to be), it would be prudent to open a discussion in
  advance of the PR to avoid doing large amounts of work that might not
  get merged. -->

This PR fix's #517  & #549.

1. Added Spacer(),  so the space from the top of the title to the platform information should match the space from the bottom of the title to the Date. Fix for #517 
2. Fixed Lesson list top/bottom padding issue for Download Icon using a VStack to center it. 

Screenshots approved by @luke-freeman see comments in  #517  & #549.
<!-- When this PR is merged, a new version of emitron will be pushed to Testflight automatically -->
