### PR TITLE
Fixed swiftlint warning

### DIFF
--- a/Emitron/.swiftlint.yml
+++ b/Emitron/.swiftlint.yml
@@ -51,7 +51,6 @@ opt_in_rules:
   - unowned_variable_capture
   - untyped_error_in_catch
   - unused_import
-  - unused_private_declaration
   - vertical_parameter_alignment_on_call
   - vertical_whitespace_closing_braces
   - xct_specific_matcher

--- a/Emitron/.swiftlint.yml
+++ b/Emitron/.swiftlint.yml
@@ -79,10 +79,6 @@ large_tuple:
   - 3 # warning
   - 4 # error
 
-line_length:
-  - 150 # warning
-  - 200 # error
-
 file_length:
   - 1200 # warning
   - 1500 # error


### PR DESCRIPTION
<!-- 🚀 Thank you for contributing! -->

<!-- Describe your changes clearly and use examples if possible. -->

<!-- If this PR fixes an issue, then please link to that issue. If the PR
  is large (or likely to be), it would be prudent to open a discussion in
  advance of the PR to avoid doing large amounts of work that might not
  get merged. -->

<!-- When this PR is merged, a new version of emitron will be pushed to Testflight automatically -->

Fixed the following Fixed swiftlint warning's when using swiftlint version 0.43.1 

- warning: Found a configuration for 'line_length' rule, but it is disabled on 'disabled_rules'.
- warning: 'unused_private_declaration' is not a valid rule identifier