### PR TITLE
Remove unused Variable to clear compiler warning

### DIFF
--- a/Emitron/Emitron/UI/SceneDelegate.swift
+++ b/Emitron/Emitron/UI/SceneDelegate.swift
@@ -70,7 +70,6 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
       let mainView = MainView()
         .environmentObject(sessionController)
         .environmentObject(dataManager)
-      let date = Calendar.current.date(byAdding: .day, value: -20, to: Date())
       if NSUbiquitousKeyValueStore.default.object(forKey: LookupKey.requestReview) == nil {
         NSUbiquitousKeyValueStore.default.set(Date().timeIntervalSince1970, forKey: LookupKey.requestReview)
       }


### PR DESCRIPTION
This removes the unused Variable to clear the compiler warning shown below:

<img width="1265" alt="Screenshot 2021-05-03 at 21 26 46" src="https://user-images.githubusercontent.com/4116539/116916704-5a795c80-ac56-11eb-90d6-beb809d7c406.png">


Signed-off-by: Franklin Byaruhanga <byaruhaf@appbantu.com>

<!-- 🚀 Thank you for contributing! -->

<!-- Describe your changes clearly and use examples if possible. -->

<!-- If this PR fixes an issue, then please link to that issue. If the PR
  is large (or likely to be), it would be prudent to open a discussion in
  advance of the PR to avoid doing large amounts of work that might not
  get merged. -->

<!-- When this PR is merged, a new version of emitron will be pushed to Testflight automatically -->
