### PR TITLE
Fix invalid urlScheme

### DIFF
--- a/Emitron/Emitron/AppDelegate.swift
+++ b/Emitron/Emitron/AppDelegate.swift
@@ -58,7 +58,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     let dbPool = try! setupDatabase(application)
     persistenceStore = PersistenceStore(db: dbPool)
     guardpost = Guardpost(baseURL: "https://accounts.raywenderlich.com",
-                          urlScheme: "com.razeware.emitron://",
+                          urlScheme: "com.razeware.emitron",
                           ssoSecret: Configuration.ssoSecret,
                           persistenceStore: persistenceStore)
     

--- a/Emitron/Emitron/Guardpost/Guardpost.swift
+++ b/Emitron/Emitron/Guardpost/Guardpost.swift
@@ -93,7 +93,7 @@ public class Guardpost {
     }
 
     authSession = ASWebAuthenticationSession(url: loginURL,
-                                             callbackURLScheme: urlScheme) { url, error in
+                                             callbackURLScheme: String(urlScheme.dropLast(3))) { url, error in
 
       var result: Result<User, LoginError>
 

--- a/Emitron/Emitron/Guardpost/Guardpost.swift
+++ b/Emitron/Emitron/Guardpost/Guardpost.swift
@@ -82,7 +82,7 @@ public class Guardpost {
 
   public func login(callback: @escaping (Result<User, LoginError>) -> Void) {
     let guardpostLogin = "\(baseURL)/v2/sso/login"
-    let returnURL = "\(urlScheme)sessions/create"
+    let returnURL = "\(urlScheme)://sessions/create"
     let ssoRequest = SingleSignOnRequest(endpoint: guardpostLogin,
                                          secret: ssoSecret,
                                          callbackURL: returnURL)
@@ -93,7 +93,7 @@ public class Guardpost {
     }
 
     authSession = ASWebAuthenticationSession(url: loginURL,
-                                             callbackURLScheme: String(urlScheme.dropLast(3))) { url, error in
+                                             callbackURLScheme: urlScheme) { url, error in
 
       var result: Result<User, LoginError>
 


### PR DESCRIPTION
Fix invalid URL scheme causing issue #575  by removing special, characters.

So URL scheme: `"com.razeware.emitron://" ` is replaced by  `"com.razeware.emitron"`

Matching the URL scheme in info.plist




<img width="1089" alt="Screenshot 2021-05-13 at 17 09 29" src="https://user-images.githubusercontent.com/4116539/118140782-5e08a280-b411-11eb-9ad1-23c5dc548952.png">
<img width="706" alt="Screenshot 2021-05-13 at 17 11 49" src="https://user-images.githubusercontent.com/4116539/118140849-6c56be80-b411-11eb-99e2-f155db4af96c.png">




Closes #575 
Signed-off-by: Franklin Byaruhanga <byaruhaf@appbantu.com>

<!-- 🚀 Thank you for contributing! -->

<!-- Describe your changes clearly and use examples if possible. -->

<!-- If this PR fixes an issue, then please link to that issue. If the PR
  is large (or likely to be), it would be prudent to open a discussion in
  advance of the PR to avoid doing large amounts of work that might not
  get merged. -->

<!-- When this PR is merged, a new version of emitron will be pushed to Testflight automatically -->
