### PR TITLE
Ios13 removal

### DIFF
--- a/Emitron/Emitron.xcodeproj/project.pbxproj
+++ b/Emitron/Emitron.xcodeproj/project.pbxproj
@@ -333,6 +333,7 @@
 		B6FC15C722CB55DB0078CEDB /* JSONAPIErrorSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6FC15C622CB55DB0078CEDB /* JSONAPIErrorSource.swift */; };
 		B6FC15D522CB68E20078CEDB /* Service.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6FC15D422CB68E20078CEDB /* Service.swift */; };
 		B6FC15D722CB817C0078CEDB /* BookmarksService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6FC15D622CB817C0078CEDB /* BookmarksService.swift */; };
+		D3D9C5C72645DA9A002FD479 /* EmitronApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3D9C5C62645DA9A002FD479 /* EmitronApp.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -682,6 +683,7 @@
 		B6FC15C622CB55DB0078CEDB /* JSONAPIErrorSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONAPIErrorSource.swift; sourceTree = "<group>"; };
 		B6FC15D422CB68E20078CEDB /* Service.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Service.swift; sourceTree = "<group>"; };
 		B6FC15D622CB817C0078CEDB /* BookmarksService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarksService.swift; sourceTree = "<group>"; };
+		D3D9C5C62645DA9A002FD479 /* EmitronApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmitronApp.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -1474,6 +1476,7 @@
 				22B8265E23AF5B3400D4BA23 /* Data */,
 				22BFE75D23DACEC000495BA9 /* Data Synchronisation */,
 				B6D7DC2E22C79743006DD325 /* AppDelegate.swift */,
+				D3D9C5C62645DA9A002FD479 /* EmitronApp.swift */,
 				B6D7DC3422C79745006DD325 /* Assets.xcassets */,
 				223DECF1240989430017F7CA /* App Icons */,
 				22D177032350748E0038333D /* Configuration */,
@@ -2046,6 +2049,7 @@
 				2278AE48240A4BBC00855221 /* IconView.swift in Sources */,
 				B6419BB322EF5622003AC14E /* Logger.swift in Sources */,
 				223D77A523B06FFA005BE95D /* AttachmentAdapter.swift in Sources */,
+				D3D9C5C72645DA9A002FD479 /* EmitronApp.swift in Sources */,
 				223D77B523B0C0CA005BE95D /* Domain.swift in Sources */,
 				223D77B723B0C0D1005BE95D /* Group.swift in Sources */,
 				B6D8EB2722CBA86000DE29AF /* ProgressionsRequest.swift in Sources */,
@@ -2364,7 +2368,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 13.4;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.1;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				SDKROOT = iphoneos;
@@ -2512,7 +2516,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 13.4;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.1;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
@@ -2568,7 +2572,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 13.4;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.1;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				SDKROOT = iphoneos;

--- a/Emitron/Emitron.xcodeproj/project.pbxproj
+++ b/Emitron/Emitron.xcodeproj/project.pbxproj
@@ -2614,7 +2614,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = "AppIcon${BUNDLE_ID_SUFFIX}";
 				BUNDLE_ID_SUFFIX = "";
-				CODE_SIGN_IDENTITY = "Apple Distribution";
+				CODE_SIGN_IDENTITY = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = UNKNOWN;
 				DEVELOPMENT_ASSET_PATHS = "Emitron/Preview\\ Content";
@@ -2629,7 +2629,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.razeware.emitron.ios$(BUNDLE_ID_SUFFIX)";
 				PRODUCT_MODULE_NAME = Emitron;
 				PRODUCT_NAME = raywenderlich;
-				PROVISIONING_PROFILE_SPECIFIER = "$(sigh_com.razeware.emitron.ios_appstore_profile-name)";
+				PROVISIONING_PROFILE_SPECIFIER = "match AppStore com.razeware.emitron.ios";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};

--- a/Emitron/Emitron.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Emitron/Emitron.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/groue/CombineExpectations.git",
         "state": {
           "branch": null,
-          "revision": "96d5604151c94b21fbca6877b237e80af9e821dd",
-          "version": "0.5.0"
+          "revision": "5118f805bdeac7e81dc8e92c78b7ce475201dec8",
+          "version": "0.9.0"
         }
       },
       {

--- a/Emitron/Emitron/AppDelegate.swift
+++ b/Emitron/Emitron/AppDelegate.swift
@@ -30,77 +30,24 @@ import UIKit
 import AVFoundation
 import GRDB
 
-// swiftlint:disable strict_fileprivate
-
-@UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
-  private var persistenceStore: PersistenceStore!
-  private var guardpost: Guardpost!
-  fileprivate var dataManager: DataManager!
-  fileprivate var sessionController: SessionController!
-  fileprivate var downloadService: DownloadService!
-  fileprivate var messageBus = MessageBus()
-  fileprivate var settingsManager: SettingsManager!
-  fileprivate var iconManager = IconManager()
 
-  func applicationDidFinishLaunching(_ application: UIApplication) {
-    // Override point for customization after application launch.
-    
+  var downloadService: DownloadService?
+
+  func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil) -> Bool {
     let audioSession = AVAudioSession.sharedInstance()
     do {
       try audioSession.setCategory(AVAudioSession.Category.playback)
     } catch {
       print("Setting category to AVAudioSessionCategoryPlayback failed.")
     }
-    
-    // Initialise the database
-    // swiftlint:disable:next force_try
-    let dbPool = try! setupDatabase(application)
-    persistenceStore = PersistenceStore(db: dbPool)
-    guardpost = Guardpost(baseURL: "https://accounts.raywenderlich.com",
-                          urlScheme: "com.razeware.emitron://",
-                          ssoSecret: Configuration.ssoSecret,
-                          persistenceStore: persistenceStore)
-    
-    sessionController = SessionController(guardpost: guardpost)
-    settingsManager = SettingsManager(
-      userDefaults: .standard,
-      userModelController: sessionController
-    )
-    downloadService = DownloadService(
-      persistenceStore: persistenceStore,
-      userModelController: sessionController
-    )
-    dataManager = DataManager(
-      sessionController: sessionController,
-      persistenceStore: persistenceStore,
-      downloadService: downloadService
-    )
-    downloadService.startProcessing()
+    return true
   }
-  
-  // MARK: UISceneSession Lifecycle
-  func application(_ application: UIApplication,
-                   configurationForConnecting connectingSceneSession: UISceneSession,
-                   options: UIScene.ConnectionOptions) -> UISceneConfiguration {
-    // Called when a new scene session is being created.
-    // Use this method to select a configuration to create the new scene with.
-    return UISceneConfiguration(name: "Default Configuration",
-                                sessionRole: connectingSceneSession.role)
-  }
-  
-  func application(_ application: UIApplication,
-                   didDiscardSceneSessions sceneSessions: Set<UISceneSession>) {
-    // Called when the user discards a scene session.
-    // If any sessions were discarded while the application was not running, this will be called shortly after application:didFinishLaunchingWithOptions.
-    // Use this method to release any resources that were specific to the discarded scenes, as they will not return.
-  }
-  
   // For dealing with downloading of videos in the background
   func application(_ application: UIApplication, handleEventsForBackgroundURLSession identifier: String, completionHandler: @escaping () -> Void) {
     assert(identifier == DownloadProcessor.sessionIdentifier, "Unknown Background URLSession. Unable to handle these events.")
     
-    downloadService.backgroundSessionCompletionHandler = completionHandler
+    downloadService?.backgroundSessionCompletionHandler = completionHandler
   }
   
   private func setupDatabase(_ application: UIApplication) throws -> DatabasePool {
@@ -108,42 +55,5 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
       .url(for: .applicationSupportDirectory, in: .userDomainMask, appropriateFor: nil, create: true)
       .appendingPathComponent("emitron.sqlite")
     return try EmitronDatabase.openDatabase(atPath: databaseURL.path)
-  }
-}
-
-// MARK: - Making some delightful global-access points. Classy.
-extension SessionController {
-  static var current: SessionController {
-    (UIApplication.shared.delegate as! AppDelegate).sessionController
-  }
-}
-
-extension DataManager {
-  static var current: DataManager {
-    (UIApplication.shared.delegate as! AppDelegate).dataManager
-  }
-}
-
-extension DownloadService {
-  static var current: DownloadService {
-    (UIApplication.shared.delegate as! AppDelegate).downloadService
-  }
-}
-
-extension MessageBus {
-  static var current: MessageBus {
-    (UIApplication.shared.delegate as! AppDelegate).messageBus
-  }
-}
-
-extension SettingsManager {
-  static var current: SettingsManager {
-    (UIApplication.shared.delegate as! AppDelegate).settingsManager
-  }
-}
-
-extension IconManager {
-  static var current: IconManager {
-    (UIApplication.shared.delegate as! AppDelegate).iconManager
   }
 }

--- a/Emitron/Emitron/Data/ContentRepositories/ContentRepository.swift
+++ b/Emitron/Emitron/Data/ContentRepositories/ContentRepository.swift
@@ -36,6 +36,7 @@ class ContentRepository: ObservableObject, ContentPaginatable {
   let serviceAdapter: ContentServiceAdapter!
   let messageBus: MessageBus
   let settingsManager: SettingsManager
+  let sessionController: SessionController
 
   private (set) var currentPage: Int = 1
   private (set) var totalContentNum: Int = 0
@@ -75,7 +76,8 @@ class ContentRepository: ObservableObject, ContentPaginatable {
        syncAction: SyncAction,
        serviceAdapter: ContentServiceAdapter?,
        messageBus: MessageBus,
-       settingsManager: SettingsManager) {
+       settingsManager: SettingsManager,
+       sessionController: SessionController) {
     self.repository = repository
     self.contentsService = contentsService
     self.downloadAction = downloadAction
@@ -83,6 +85,7 @@ class ContentRepository: ObservableObject, ContentPaginatable {
     self.serviceAdapter = serviceAdapter
     self.messageBus = messageBus
     self.settingsManager = settingsManager
+    self.sessionController = sessionController
     configureInvalidationSubscription()
   }
 
@@ -198,7 +201,8 @@ class ContentRepository: ObservableObject, ContentPaginatable {
       downloadAction: downloadAction,
       syncAction: syncAction,
       messageBus: messageBus,
-      settingsManager: settingsManager
+      settingsManager: settingsManager,
+      sessionController: sessionController
     )
   }
   
@@ -211,7 +215,8 @@ class ContentRepository: ObservableObject, ContentPaginatable {
       repository: repository,
       service: contentsService,
       messageBus: messageBus,
-      settingsManager: settingsManager
+      settingsManager: settingsManager,
+      sessionController: sessionController
     )
   }
 }

--- a/Emitron/Emitron/Data/ContentRepositories/ContentRepository.swift
+++ b/Emitron/Emitron/Data/ContentRepositories/ContentRepository.swift
@@ -34,7 +34,9 @@ class ContentRepository: ObservableObject, ContentPaginatable {
   let downloadAction: DownloadAction
   weak var syncAction: SyncAction?
   let serviceAdapter: ContentServiceAdapter!
-  
+  let messageBus: MessageBus
+  let settingsManager: SettingsManager
+
   private (set) var currentPage: Int = 1
   private (set) var totalContentNum: Int = 0
   
@@ -71,12 +73,16 @@ class ContentRepository: ObservableObject, ContentPaginatable {
        contentsService: ContentsService,
        downloadAction: DownloadAction,
        syncAction: SyncAction,
-       serviceAdapter: ContentServiceAdapter?) {
+       serviceAdapter: ContentServiceAdapter?,
+       messageBus: MessageBus,
+       settingsManager: SettingsManager) {
     self.repository = repository
     self.contentsService = contentsService
     self.downloadAction = downloadAction
     self.syncAction = syncAction
     self.serviceAdapter = serviceAdapter
+    self.messageBus = messageBus
+    self.settingsManager = settingsManager
     configureInvalidationSubscription()
   }
 
@@ -190,7 +196,9 @@ class ContentRepository: ObservableObject, ContentPaginatable {
       contentId: contentId,
       repository: repository,
       downloadAction: downloadAction,
-      syncAction: syncAction
+      syncAction: syncAction,
+      messageBus: messageBus,
+      settingsManager: settingsManager
     )
   }
   
@@ -201,7 +209,9 @@ class ContentRepository: ObservableObject, ContentPaginatable {
       downloadAction: downloadAction,
       syncAction: syncAction,
       repository: repository,
-      service: contentsService
+      service: contentsService,
+      messageBus: messageBus,
+      settingsManager: settingsManager
     )
   }
 }

--- a/Emitron/Emitron/Data/ContentRepositories/DownloadRepository.swift
+++ b/Emitron/Emitron/Data/ContentRepositories/DownloadRepository.swift
@@ -36,14 +36,18 @@ final class DownloadRepository: ContentRepository {
   init(repository: Repository,
        contentsService: ContentsService,
        downloadService: DownloadService,
-       syncAction: SyncAction) {
+       syncAction: SyncAction,
+       messageBus: MessageBus,
+       settingsManager: SettingsManager) {
     self.downloadService = downloadService
     // Don't need the repository or the service adapter
     super.init(repository: repository,
                contentsService: contentsService,
                downloadAction: downloadService,
                syncAction: syncAction,
-               serviceAdapter: nil)
+               serviceAdapter: nil,
+               messageBus: messageBus,
+               settingsManager: settingsManager)
   }
   
   override func loadMore() {
@@ -62,7 +66,9 @@ final class DownloadRepository: ContentRepository {
       parentContentId: contentId,
       downloadAction: downloadService,
       syncAction: syncAction,
-      repository: repository
+      repository: repository,
+      messageBus: messageBus,
+      settingsManager: settingsManager
     )
   }
   

--- a/Emitron/Emitron/Data/ContentRepositories/DownloadRepository.swift
+++ b/Emitron/Emitron/Data/ContentRepositories/DownloadRepository.swift
@@ -38,7 +38,8 @@ final class DownloadRepository: ContentRepository {
        downloadService: DownloadService,
        syncAction: SyncAction,
        messageBus: MessageBus,
-       settingsManager: SettingsManager) {
+       settingsManager: SettingsManager,
+       sessionController: SessionController) {
     self.downloadService = downloadService
     // Don't need the repository or the service adapter
     super.init(repository: repository,
@@ -47,7 +48,8 @@ final class DownloadRepository: ContentRepository {
                syncAction: syncAction,
                serviceAdapter: nil,
                messageBus: messageBus,
-               settingsManager: settingsManager)
+               settingsManager: settingsManager,
+               sessionController: sessionController)
   }
   
   override func loadMore() {
@@ -68,7 +70,8 @@ final class DownloadRepository: ContentRepository {
       syncAction: syncAction,
       repository: repository,
       messageBus: messageBus,
-      settingsManager: settingsManager
+      settingsManager: settingsManager,
+      sessionController: sessionController
     )
   }
   

--- a/Emitron/Emitron/Data/ContentRepositories/LibraryRepository.swift
+++ b/Emitron/Emitron/Data/ContentRepositories/LibraryRepository.swift
@@ -33,14 +33,18 @@ final class LibraryRepository: ContentRepository {
                 contentsService: ContentsService,
                 downloadAction: DownloadAction,
                 syncAction: SyncAction,
-                serviceAdapter: ContentServiceAdapter?) {
-    filters = Filters()
+                serviceAdapter: ContentServiceAdapter?,
+                messageBus: MessageBus,
+                settingsManager: SettingsManager) {
+    filters = Filters(settingsManager: settingsManager)
     
     super.init(repository: repository,
                contentsService: contentsService,
                downloadAction: downloadAction,
                syncAction: syncAction,
-               serviceAdapter: serviceAdapter)
+               serviceAdapter: serviceAdapter,
+               messageBus: messageBus,
+               settingsManager: settingsManager)
     
     nonPaginationParameters = filters.appliedParameters
   }

--- a/Emitron/Emitron/Data/ContentRepositories/LibraryRepository.swift
+++ b/Emitron/Emitron/Data/ContentRepositories/LibraryRepository.swift
@@ -35,7 +35,8 @@ final class LibraryRepository: ContentRepository {
                 syncAction: SyncAction,
                 serviceAdapter: ContentServiceAdapter?,
                 messageBus: MessageBus,
-                settingsManager: SettingsManager) {
+                settingsManager: SettingsManager,
+                sessionController: SessionController) {
     filters = Filters(settingsManager: settingsManager)
     
     super.init(repository: repository,
@@ -44,7 +45,8 @@ final class LibraryRepository: ContentRepository {
                syncAction: syncAction,
                serviceAdapter: serviceAdapter,
                messageBus: messageBus,
-               settingsManager: settingsManager)
+               settingsManager: settingsManager,
+               sessionController: sessionController)
     
     nonPaginationParameters = filters.appliedParameters
   }

--- a/Emitron/Emitron/Data/DataManager.swift
+++ b/Emitron/Emitron/Data/DataManager.swift
@@ -111,14 +111,14 @@ final class DataManager: ObservableObject {
       watchStatsService: watchStatsService
     )
     
-    bookmarkRepository = BookmarkRepository(repository: repository, contentsService: contentsService, downloadAction: downloadService, syncAction: syncEngine, serviceAdapter: bookmarksService, messageBus: messageBus, settingsManager: settingsManager)
+    bookmarkRepository = BookmarkRepository(repository: repository, contentsService: contentsService, downloadAction: downloadService, syncAction: syncEngine, serviceAdapter: bookmarksService, messageBus: messageBus, settingsManager: settingsManager, sessionController: sessionController)
   
-    completedRepository = CompletedRepository(repository: repository, contentsService: contentsService, downloadAction: downloadService, syncAction: syncEngine, serviceAdapter: progressionsService, messageBus: messageBus, settingsManager: settingsManager)
-    inProgressRepository = InProgressRepository(repository: repository, contentsService: contentsService, downloadAction: downloadService, syncAction: syncEngine, serviceAdapter: progressionsService, messageBus: messageBus, settingsManager: settingsManager)
+    completedRepository = CompletedRepository(repository: repository, contentsService: contentsService, downloadAction: downloadService, syncAction: syncEngine, serviceAdapter: progressionsService, messageBus: messageBus, settingsManager: settingsManager, sessionController: sessionController)
+    inProgressRepository = InProgressRepository(repository: repository, contentsService: contentsService, downloadAction: downloadService, syncAction: syncEngine, serviceAdapter: progressionsService, messageBus: messageBus, settingsManager: settingsManager, sessionController: sessionController)
     
-    libraryRepository = LibraryRepository(repository: repository, contentsService: contentsService, downloadAction: downloadService, syncAction: syncEngine, serviceAdapter: libraryService, messageBus: messageBus, settingsManager: settingsManager)
+    libraryRepository = LibraryRepository(repository: repository, contentsService: contentsService, downloadAction: downloadService, syncAction: syncEngine, serviceAdapter: libraryService, messageBus: messageBus, settingsManager: settingsManager, sessionController: sessionController)
     
-    downloadRepository = DownloadRepository(repository: repository, contentsService: contentsService, downloadService: downloadService, syncAction: syncEngine, messageBus: messageBus, settingsManager: settingsManager)
+    downloadRepository = DownloadRepository(repository: repository, contentsService: contentsService, downloadService: downloadService, syncAction: syncEngine, messageBus: messageBus, settingsManager: settingsManager, sessionController: sessionController)
     
     domainRepository = DomainRepository(repository: repository, service: domainsService)
     domainsSubscriber = domainRepository.$domains.sink { domains in

--- a/Emitron/Emitron/Data/DataManager.swift
+++ b/Emitron/Emitron/Data/DataManager.swift
@@ -36,12 +36,15 @@ final class DataManager: ObservableObject {
   let persistenceStore: PersistenceStore
   let downloadService: DownloadService
   let sessionController: SessionController
+  let messageBus: MessageBus
+  let settingsManager: SettingsManager
+
   private (set) var sessionControllerSubscription: AnyCancellable!
 
   // Persisted information
   private (set) var domainRepository: DomainRepository!
   private (set) var categoryRepository: CategoryRepository!
-  var filters = Filters()
+  var filters: Filters
   
   // Cached data
   var dataCache = DataCache()
@@ -63,11 +66,16 @@ final class DataManager: ObservableObject {
   // MARK: - Initializers
   init(sessionController: SessionController,
        persistenceStore: PersistenceStore,
-       downloadService: DownloadService) {
+       downloadService: DownloadService,
+       messageBus: MessageBus,
+       settingsManager: SettingsManager) {
     
     self.downloadService = downloadService
     self.persistenceStore = persistenceStore
     self.sessionController = sessionController
+    self.messageBus = messageBus
+    self.settingsManager = settingsManager
+    self.filters = Filters(settingsManager: settingsManager)
     
     sessionControllerSubscription = sessionController.objectWillChange.sink { [weak self] in
       guard let self = self else { return }
@@ -83,7 +91,7 @@ final class DataManager: ObservableObject {
     
     // Empty the caches
     dataCache = DataCache()
-    filters = Filters()
+    filters = Filters(settingsManager: settingsManager)
     
     repository = Repository(persistenceStore: persistenceStore, dataCache: dataCache)
     
@@ -103,14 +111,14 @@ final class DataManager: ObservableObject {
       watchStatsService: watchStatsService
     )
     
-    bookmarkRepository = BookmarkRepository(repository: repository, contentsService: contentsService, downloadAction: downloadService, syncAction: syncEngine, serviceAdapter: bookmarksService)
+    bookmarkRepository = BookmarkRepository(repository: repository, contentsService: contentsService, downloadAction: downloadService, syncAction: syncEngine, serviceAdapter: bookmarksService, messageBus: messageBus, settingsManager: settingsManager)
   
-    completedRepository = CompletedRepository(repository: repository, contentsService: contentsService, downloadAction: downloadService, syncAction: syncEngine, serviceAdapter: progressionsService)
-    inProgressRepository = InProgressRepository(repository: repository, contentsService: contentsService, downloadAction: downloadService, syncAction: syncEngine, serviceAdapter: progressionsService)
+    completedRepository = CompletedRepository(repository: repository, contentsService: contentsService, downloadAction: downloadService, syncAction: syncEngine, serviceAdapter: progressionsService, messageBus: messageBus, settingsManager: settingsManager)
+    inProgressRepository = InProgressRepository(repository: repository, contentsService: contentsService, downloadAction: downloadService, syncAction: syncEngine, serviceAdapter: progressionsService, messageBus: messageBus, settingsManager: settingsManager)
     
-    libraryRepository = LibraryRepository(repository: repository, contentsService: contentsService, downloadAction: downloadService, syncAction: syncEngine, serviceAdapter: libraryService)
+    libraryRepository = LibraryRepository(repository: repository, contentsService: contentsService, downloadAction: downloadService, syncAction: syncEngine, serviceAdapter: libraryService, messageBus: messageBus, settingsManager: settingsManager)
     
-    downloadRepository = DownloadRepository(repository: repository, contentsService: contentsService, downloadService: downloadService, syncAction: syncEngine)
+    downloadRepository = DownloadRepository(repository: repository, contentsService: contentsService, downloadService: downloadService, syncAction: syncEngine, messageBus: messageBus, settingsManager: settingsManager)
     
     domainRepository = DomainRepository(repository: repository, service: domainsService)
     domainsSubscriber = domainRepository.$domains.sink { domains in

--- a/Emitron/Emitron/Data/ViewModels/ChildContentsViewModel.swift
+++ b/Emitron/Emitron/Data/ViewModels/ChildContentsViewModel.swift
@@ -35,6 +35,7 @@ class ChildContentsViewModel: ObservableObject {
   let repository: Repository
   let messageBus: MessageBus
   let settingsManager: SettingsManager
+  let sessionController: SessionController
   
   var state: DataState = .initial
   @Published var groups: [GroupDisplayable] = []
@@ -47,13 +48,15 @@ class ChildContentsViewModel: ObservableObject {
        syncAction: SyncAction?,
        repository: Repository,
        messageBus: MessageBus,
-       settingsManager: SettingsManager) {
+       settingsManager: SettingsManager,
+       sessionController: SessionController) {
     self.parentContentId = parentContentId
     self.downloadAction = downloadAction
     self.syncAction = syncAction
     self.repository = repository
     self.messageBus = messageBus
     self.settingsManager = settingsManager
+    self.sessionController = sessionController
   }
   
   func initialiseIfRequired() {
@@ -110,7 +113,8 @@ class ChildContentsViewModel: ObservableObject {
       downloadAction: downloadAction,
       syncAction: syncAction,
       messageBus: messageBus,
-      settingsManager: settingsManager
+      settingsManager: settingsManager,
+      sessionController: sessionController
     )
   }
 }

--- a/Emitron/Emitron/Data/ViewModels/ChildContentsViewModel.swift
+++ b/Emitron/Emitron/Data/ViewModels/ChildContentsViewModel.swift
@@ -33,6 +33,8 @@ class ChildContentsViewModel: ObservableObject {
   let downloadAction: DownloadAction
   weak var syncAction: SyncAction?
   let repository: Repository
+  let messageBus: MessageBus
+  let settingsManager: SettingsManager
   
   var state: DataState = .initial
   @Published var groups: [GroupDisplayable] = []
@@ -43,11 +45,15 @@ class ChildContentsViewModel: ObservableObject {
   init(parentContentId: Int,
        downloadAction: DownloadAction,
        syncAction: SyncAction?,
-       repository: Repository) {
+       repository: Repository,
+       messageBus: MessageBus,
+       settingsManager: SettingsManager) {
     self.parentContentId = parentContentId
     self.downloadAction = downloadAction
     self.syncAction = syncAction
     self.repository = repository
+    self.messageBus = messageBus
+    self.settingsManager = settingsManager
   }
   
   func initialiseIfRequired() {
@@ -102,7 +108,9 @@ class ChildContentsViewModel: ObservableObject {
       contentId: contentId,
       repository: repository,
       downloadAction: downloadAction,
-      syncAction: syncAction
+      syncAction: syncAction,
+      messageBus: messageBus,
+      settingsManager: settingsManager
     )
   }
 }

--- a/Emitron/Emitron/Data/ViewModels/DataCacheChildContentsViewModel.swift
+++ b/Emitron/Emitron/Data/ViewModels/DataCacheChildContentsViewModel.swift
@@ -33,12 +33,16 @@ final class DataCacheChildContentsViewModel: ChildContentsViewModel {
        downloadAction: DownloadAction,
        syncAction: SyncAction?,
        repository: Repository,
-       service: ContentsService) {
+       service: ContentsService,
+       messageBus: MessageBus,
+       settingsManager: SettingsManager) {
     self.service = service
     super.init(parentContentId: parentContentId,
                downloadAction: downloadAction,
                syncAction: syncAction,
-               repository: repository)
+               repository: repository,
+               messageBus: messageBus,
+               settingsManager: settingsManager)
   }
   
   override func loadContentDetailsIntoCache() {

--- a/Emitron/Emitron/Data/ViewModels/DataCacheChildContentsViewModel.swift
+++ b/Emitron/Emitron/Data/ViewModels/DataCacheChildContentsViewModel.swift
@@ -35,14 +35,16 @@ final class DataCacheChildContentsViewModel: ChildContentsViewModel {
        repository: Repository,
        service: ContentsService,
        messageBus: MessageBus,
-       settingsManager: SettingsManager) {
+       settingsManager: SettingsManager,
+       sessionController: SessionController) {
     self.service = service
     super.init(parentContentId: parentContentId,
                downloadAction: downloadAction,
                syncAction: syncAction,
                repository: repository,
                messageBus: messageBus,
-               settingsManager: settingsManager)
+               settingsManager: settingsManager,
+               sessionController: sessionController)
   }
   
   override func loadContentDetailsIntoCache() {

--- a/Emitron/Emitron/Data/ViewModels/DynamicContentViewModel.swift
+++ b/Emitron/Emitron/Data/ViewModels/DynamicContentViewModel.swift
@@ -37,6 +37,7 @@ final class DynamicContentViewModel: ObservableObject, DynamicContentDisplayable
   private weak var syncAction: SyncAction?
   private let messageBus: MessageBus
   private let settingsManager: SettingsManager
+  private let sessionController: SessionController
   
   private var dynamicContentState: DynamicContentState?
   
@@ -44,18 +45,18 @@ final class DynamicContentViewModel: ObservableObject, DynamicContentDisplayable
   @Published var viewProgress: ContentViewProgressDisplayable = .notStarted
   @Published var downloadProgress: DownloadProgressDisplayable = .notDownloadable
   @Published var bookmarked = false
-  @EnvironmentObject private var sessionController: SessionController
 
   private var subscriptions = Set<AnyCancellable>()
   private var downloadActionSubscriptions = Set<AnyCancellable>()
   
-  init(contentId: Int, repository: Repository, downloadAction: DownloadAction, syncAction: SyncAction?, messageBus: MessageBus, settingsManager: SettingsManager) {
+  init(contentId: Int, repository: Repository, downloadAction: DownloadAction, syncAction: SyncAction?, messageBus: MessageBus, settingsManager: SettingsManager, sessionController: SessionController) {
     self.contentId = contentId
     self.repository = repository
     self.downloadAction = downloadAction
     self.syncAction = syncAction
     self.messageBus = messageBus
     self.settingsManager = settingsManager
+    self.sessionController = sessionController
   }
   
   func initialiseIfRequired() {

--- a/Emitron/Emitron/Data/ViewModels/PersistenceStoreChildContentsViewModel.swift
+++ b/Emitron/Emitron/Data/ViewModels/PersistenceStoreChildContentsViewModel.swift
@@ -29,13 +29,14 @@
 import class Foundation.DispatchQueue
 
 final class PersistenceStoreChildContentsViewModel: ChildContentsViewModel {
+
   override func loadContentDetailsIntoCache() {
     do {
       try repository.loadDownloadedChildContentsIntoCache(for: parentContentId)
       DispatchQueue.main.async(execute: reload)
     } catch {
       state = .failed
-      MessageBus.current.post(message: Message(level: .error, message: .downloadedContentNotFound))
+      messageBus.post(message: Message(level: .error, message: .downloadedContentNotFound))
     }
   }
 }

--- a/Emitron/Emitron/Downloads/DownloadProcessor.swift
+++ b/Emitron/Emitron/Downloads/DownloadProcessor.swift
@@ -79,7 +79,14 @@ final class DownloadProcessor: NSObject {
   static let sessionIdentifier = "com.razeware.emitron.DownloadProcessor"
   static let sdBitrate = 250_000
   private var downloadQuality: Attachment.Kind {
-    SettingsManager.current.downloadQuality
+    settingsManager.downloadQuality
+  }
+  private let settingsManager: SettingsManager
+
+  init(settingsManager: SettingsManager) {
+    self.settingsManager = settingsManager
+    super.init()
+    populateDownloadListFromSession()
   }
   
   private lazy var session: AVAssetDownloadURLSession = {
@@ -94,11 +101,6 @@ final class DownloadProcessor: NSObject {
   private var currentDownloads = [AVAssetDownloadTask]()
   private var throttleList = [UUID: Double]()
   weak var delegate: DownloadProcessorDelegate!
-  
-  override init() {
-    super.init()
-    populateDownloadListFromSession()
-  }
 }
 
 extension DownloadProcessor {

--- a/Emitron/Emitron/Downloads/DownloadService.swift
+++ b/Emitron/Emitron/Downloads/DownloadService.swift
@@ -30,7 +30,7 @@ import Combine
 import Foundation
 import Network
 
-final class DownloadService {
+final class DownloadService: ObservableObject {
   enum Status {
     case active
     case inactive
@@ -50,7 +50,7 @@ final class DownloadService {
   private let videosServiceProvider: VideosService.Provider
   private var videosService: VideosService?
   private let queueManager: DownloadQueueManager
-  private let downloadProcessor = DownloadProcessor()
+  private let downloadProcessor: DownloadProcessor
   private var processingSubscriptions = Set<AnyCancellable>()
   
   private let networkMonitor = NWPathMonitor()
@@ -59,7 +59,7 @@ final class DownloadService {
   private var downloadQueueSubscription: AnyCancellable?
   
   private var downloadQuality: Attachment.Kind {
-    SettingsManager.current.downloadQuality
+   settingsManager.downloadQuality
   }
   private lazy var downloadsDirectory: URL = {
     let fileManager = FileManager.default
@@ -79,13 +79,17 @@ final class DownloadService {
       downloadProcessor.backgroundSessionCompletionHandler = newValue
     }
   }
+
+  let settingsManager: SettingsManager
   
   // MARK: Initialisers
-  init(persistenceStore: PersistenceStore, userModelController: UserModelController, videosServiceProvider: VideosService.Provider? = .none) {
+  init(persistenceStore: PersistenceStore, userModelController: UserModelController, videosServiceProvider: VideosService.Provider? = .none, settingsManager: SettingsManager) {
     self.persistenceStore = persistenceStore
     self.userModelController = userModelController
+    downloadProcessor = DownloadProcessor(settingsManager: settingsManager)
     queueManager = DownloadQueueManager(persistenceStore: persistenceStore, maxSimultaneousDownloads: 3)
     self.videosServiceProvider = videosServiceProvider ?? { VideosService(client: $0) }
+    self.settingsManager = settingsManager
     userModelControllerSubscription = userModelController.objectDidChange.sink { [weak self] in
       self?.stopProcessing()
       self?.checkPermissions()
@@ -199,7 +203,7 @@ extension DownloadService: DownloadAction {
     let currentlyDownloading = downloads.filter { $0.isDownloading }
     let notYetDownloading = downloads.filter { !$0.isDownloading }
     
-    return Future { promise in
+    return Future<Void, Error> { promise in
       do {
         // It's in the download process, so let's ask it to cancel it.
         // The delegate callback will handle deleting the value in
@@ -210,7 +214,7 @@ extension DownloadService: DownloadAction {
         promise(.failure(error))
       }
     }
-    .flatMap {
+    .flatMap { _ in
       // Don't have it in the processor, so we just need to
       // delete the download model
       self.persistenceStore
@@ -239,7 +243,7 @@ extension DownloadService: DownloadAction {
       try? persistenceStore.download(forContentId: $0)
     }
     
-    return Future { promise in
+    return Future<Void, Error> { promise in
       do {
         // 2. Delete the file from disk
         try downloads
@@ -535,7 +539,7 @@ extension DownloadService {
     networkMonitor.start(queue: DispatchQueue.global(qos: .utility))
     
     // Track the status of the wifi downloads setting
-    settingsSubscription = SettingsManager.current
+    settingsSubscription = settingsManager
       .wifiOnlyDownloadsPublisher
       .removeDuplicates()
       .sink(receiveValue: { [weak self] _ in
@@ -548,7 +552,7 @@ extension DownloadService {
       guard let self = self else { return }
       
       let expensive = self.networkMonitor.currentPath.isExpensive
-      let allowedExpensive = !SettingsManager.current.wifiOnlyDownloads
+      let allowedExpensive = self.settingsManager.wifiOnlyDownloads
       self.status = Status.status(expensive: expensive, expensiveAllowed: allowedExpensive)
       
       switch self.status {

--- a/Emitron/Emitron/EmitronApp.swift
+++ b/Emitron/Emitron/EmitronApp.swift
@@ -1,0 +1,176 @@
+// Copyright (c) 2021 Razeware LLC
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// Notwithstanding the foregoing, you may not use, copy, modify, merge, publish,
+// distribute, sublicense, create a derivative work, and/or sell copies of the
+// Software in any work that is designed, intended, or marketed for pedagogical or
+// instructional purposes related to programming, coding, application development,
+// or information technology.  Permission for such use, copying, modification,
+// merger, publication, distribution, sublicensing, creation of derivative works,
+// or sale is expressly withheld.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+import SwiftUI
+import GRDB
+
+@main
+struct EmitronApp: App {
+
+  @UIApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
+
+  typealias EmitronObjects = (persistenceStore: PersistenceStore, guardpost: Guardpost, sessionController: SessionController, settingsManager: SettingsManager, downloadService: DownloadService, dataManager: DataManager, messageBus: MessageBus)
+
+  private var persistenceStore: PersistenceStore
+  private var guardpost: Guardpost
+  private var dataManager: DataManager
+  private var sessionController: SessionController
+  private var downloadService: DownloadService
+  private var settingsManager: SettingsManager
+  private var messageBus: MessageBus
+  private var iconManager: IconManager
+  
+  init() {
+
+    // setup objects
+    let emitronObjects = EmitronApp.emitronObjects()
+    persistenceStore = emitronObjects.persistenceStore
+    guardpost = emitronObjects.guardpost
+    dataManager = emitronObjects.dataManager
+    sessionController = emitronObjects.sessionController
+    downloadService = emitronObjects.downloadService
+    settingsManager = emitronObjects.settingsManager
+    messageBus = emitronObjects.messageBus
+    iconManager = IconManager(messageBus: messageBus)
+
+    // start service
+    appDelegate.downloadService = downloadService
+    downloadService.startProcessing()
+
+    // configure ui
+    customizeNavigationBar()
+    customizeTableView()
+    customizeControls()
+
+    // additional setup
+    setupAppReview()
+  }
+
+  var body: some Scene {
+    WindowGroup {
+      MainView()
+        .environmentObject(sessionController)
+        .environmentObject(dataManager)
+        .environmentObject(downloadService)
+        .environmentObject(iconManager)
+        .environmentObject(messageBus)
+        .environmentObject(persistenceStore)
+        .environmentObject(guardpost)
+        .environmentObject(settingsManager)
+    }
+  }
+
+  static func emitronObjects() -> EmitronObjects {
+    // Initialise the database
+    // swiftlint:disable:next force_try
+    let databaseURL = try! FileManager.default
+      .url(for: .applicationSupportDirectory, in: .userDomainMask, appropriateFor: nil, create: true)
+      .appendingPathComponent("emitron.sqlite")
+    // swiftlint:disable:next force_try
+    let databasePool = try! EmitronDatabase.openDatabase(atPath: databaseURL.path)
+    let persistenceStore = PersistenceStore(db: databasePool)
+    let guardpost = Guardpost(baseURL: "https://accounts.raywenderlich.com",
+                              urlScheme: "com.razeware.emitron",
+                              ssoSecret: Configuration.ssoSecret,
+                              persistenceStore: persistenceStore)
+    let sessionController = SessionController(guardpost: guardpost)
+    let settingsManager = SettingsManager(userDefaults: .standard, userModelController: sessionController)
+    let downloadService = DownloadService(persistenceStore: persistenceStore, userModelController: sessionController, settingsManager: settingsManager)
+    let messageBus = MessageBus()
+    let dataManager = DataManager(sessionController: sessionController, persistenceStore: persistenceStore, downloadService: downloadService, messageBus: messageBus, settingsManager: settingsManager)
+
+    return EmitronObjects(persistenceStore: persistenceStore, guardpost: guardpost, sessionController: sessionController, settingsManager: settingsManager, downloadService: downloadService, dataManager: dataManager, messageBus: messageBus)
+  }
+
+  private mutating func startServices() {
+    // guardpost
+    guardpost = Guardpost(baseURL: "https://accounts.raywenderlich.com",
+                          urlScheme: "com.razeware.emitron://",
+                          ssoSecret: Configuration.ssoSecret,
+                          persistenceStore: persistenceStore)
+
+    // session controller
+    sessionController = SessionController(guardpost: guardpost)
+
+    // settings
+    settingsManager = SettingsManager(
+      userDefaults: .standard,
+      userModelController: sessionController
+    )
+
+    // download service
+    downloadService = DownloadService(
+      persistenceStore: persistenceStore,
+      userModelController: sessionController,
+      settingsManager: settingsManager
+    )
+    appDelegate.downloadService = downloadService
+
+    // data manager
+    dataManager = DataManager(
+      sessionController: sessionController,
+      persistenceStore: persistenceStore,
+      downloadService: downloadService,
+      messageBus: messageBus,
+      settingsManager: settingsManager
+    )
+    downloadService.startProcessing()
+  }
+
+  private func customizeNavigationBar() {
+    UINavigationBar.appearance().backgroundColor = .backgroundColor
+
+    UINavigationBar.appearance().largeTitleTextAttributes = [
+      NSAttributedString.Key.foregroundColor: UIColor(named: "titleText")!,
+      NSAttributedString.Key.font: UIFont.uiLargeTitle
+    ]
+    UINavigationBar.appearance().titleTextAttributes = [
+      NSAttributedString.Key.foregroundColor: UIColor(named: "titleText")!,
+      NSAttributedString.Key.font: UIFont.uiHeadline
+    ]
+  }
+
+  private func customizeTableView() {
+    UITableView.appearance().separatorColor = .clear
+    UITableViewCell.appearance().backgroundColor = .backgroundColor
+    UITableViewCell.appearance().selectionStyle = .none
+
+    UITableView.appearance().backgroundColor = .backgroundColor
+  }
+
+  private func customizeControls() {
+    UISwitch.appearance().onTintColor = .accent
+  }
+
+  private func setupAppReview() {
+    if NSUbiquitousKeyValueStore.default.object(forKey: LookupKey.requestReview) == nil {
+      NSUbiquitousKeyValueStore.default.set(Date().timeIntervalSince1970, forKey: LookupKey.requestReview)
+    }
+  }
+}

--- a/Emitron/Emitron/EmitronApp.swift
+++ b/Emitron/Emitron/EmitronApp.swift
@@ -74,15 +74,20 @@ struct EmitronApp: App {
 
   var body: some Scene {
     WindowGroup {
-      MainView()
-        .environmentObject(sessionController)
-        .environmentObject(dataManager)
-        .environmentObject(downloadService)
-        .environmentObject(iconManager)
-        .environmentObject(messageBus)
-        .environmentObject(persistenceStore)
-        .environmentObject(guardpost)
-        .environmentObject(settingsManager)
+      ZStack {
+        Rectangle()
+          .fill(Color.backgroundColor)
+          .edgesIgnoringSafeArea(.all)
+        MainView()
+          .environmentObject(sessionController)
+          .environmentObject(dataManager)
+          .environmentObject(downloadService)
+          .environmentObject(iconManager)
+          .environmentObject(messageBus)
+          .environmentObject(persistenceStore)
+          .environmentObject(guardpost)
+          .environmentObject(settingsManager)
+      }
     }
   }
 

--- a/Emitron/Emitron/Filters/Filters.swift
+++ b/Emitron/Emitron/Filters/Filters.swift
@@ -110,6 +110,7 @@ class Filters: ObservableObject {
   private(set) var difficulties: FilterGroup
   private(set) var subscriptionPlans: FilterGroup
   private(set) var searchFilter: Filter?
+  private var settingsManager: SettingsManager
   
   private var defaultParameters: [Parameter] {
     let sortParam = Param.sort(for: .releasedAt, descending: true)
@@ -124,10 +125,11 @@ class Filters: ObservableObject {
     return contentParams
   }
   
-  init() {
+  init(settingsManager: SettingsManager) {
     sortFilter = SortFilter.newest
     platforms = FilterGroup(type: .platforms)
     categories = FilterGroup(type: .categories)
+    self.settingsManager = settingsManager
     
     let contentFilters = Param
       .filters(for: [.contentTypes(types: [.collection, .screencast])])
@@ -145,7 +147,7 @@ class Filters: ObservableObject {
     subscriptionPlans = FilterGroup(type: .subscriptionPlans, filters: subscriptionPlanFilters)
     
     // Check if there are filters in the settings manager
-    let savedFilters = SettingsManager.current.filters
+    let savedFilters = settingsManager.filters
     if !savedFilters.isEmpty {
       // Validate loaded settings and put them in the right places
       platforms.updateFilters(from: savedFilters)
@@ -164,7 +166,7 @@ class Filters: ObservableObject {
     all = freshFilters
     
     // Load the sort from the settings manager
-    sortFilter = SettingsManager.current.sortFilter
+    sortFilter = settingsManager.sortFilter
   }
   
   func update(with filter: Filter) {
@@ -218,12 +220,12 @@ class Filters: ObservableObject {
   
   func changeSortFilter() {
     sortFilter = sortFilter.next
-    SettingsManager.current.sortFilter = sortFilter
+    settingsManager.sortFilter = sortFilter
     objectWillChange.send()
   }
   
   func commitUpdates() {
-    SettingsManager.current.filters = all
+    settingsManager.filters = all
     objectWillChange.send()
   }
   

--- a/Emitron/Emitron/Guardpost/Guardpost.swift
+++ b/Emitron/Emitron/Guardpost/Guardpost.swift
@@ -27,6 +27,7 @@
 // THE SOFTWARE.
 
 import AuthenticationServices
+import Combine
 
 public enum LoginError: Error {
   case unableToCreateLoginURL
@@ -52,7 +53,7 @@ public enum LoginError: Error {
   }
 }
 
-public class Guardpost {
+public class Guardpost: ObservableObject {
   // MARK: - Properties
   private let baseURL: String
   private let urlScheme: String

--- a/Emitron/Emitron/Persistence/PersistenceStore.swift
+++ b/Emitron/Emitron/Persistence/PersistenceStore.swift
@@ -26,6 +26,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+import Combine
 import class Foundation.DispatchQueue
 import GRDB
 
@@ -35,7 +36,7 @@ enum PersistenceStoreError: Error {
 }
 
 // The object responsible for managing and accessing cached content
-final class PersistenceStore {
+final class PersistenceStore: ObservableObject {
   let db: DatabaseWriter
   let workerQueue = DispatchQueue(label: "com.razeware.emitron.persistence", qos: .background)
   

--- a/Emitron/Emitron/Settings/IconManager.swift
+++ b/Emitron/Emitron/Settings/IconManager.swift
@@ -31,26 +31,28 @@ import Combine
 
 class IconManager: ObservableObject {
   private(set) var icons = [Icon]()
+  let messageBus: MessageBus
   @Published private(set) var currentIcon: Icon?
   
-  init() {
-    populateIcons()
+  init(messageBus: MessageBus) {
       
     let currentIconName = UIApplication.shared.alternateIconName
-    currentIcon = icons.first { $0.name == currentIconName }!
+    currentIcon = icons.first { $0.name == currentIconName }
+    self.messageBus = messageBus
+    populateIcons()
   }
   
   func set(icon: Icon) {
     UIApplication.shared.setAlternateIconName(icon.name) { error in
-      DispatchQueue.main.async {
+      DispatchQueue.main.async { 
         if let error = error {
           Failure
             .appIcon(from: String(describing: type(of: self)), reason: error.localizedDescription)
             .log()
-          MessageBus.current.post(message: Message(level: .error, message: .appIconUpdateProblem))
+          self.messageBus.post(message: Message(level: .error, message: .appIconUpdateProblem))
         } else {
           self.currentIcon = icon
-          MessageBus.current.post(message: Message(level: .success, message: .appIconUpdatedSuccessfully))
+          self.messageBus.post(message: Message(level: .success, message: .appIconUpdatedSuccessfully))
         }
       }
     }

--- a/Emitron/Emitron/Styleguide/Font+Extensions.swift
+++ b/Emitron/Emitron/Styleguide/Font+Extensions.swift
@@ -30,57 +30,29 @@ import SwiftUI
 
 extension Font {
   static var uiLargeTitle: Font {
-    if #available(iOS 14, *) {
-      return Font.custom("Bitter-Bold", size: 34.0, relativeTo: .largeTitle)
-    } else {
-      return Font.custom("Bitter-Bold", size: UIFontMetrics.default.scaledValue(for: 34.0))
-    }
+    Font.custom("Bitter-Bold", size: 34.0, relativeTo: .largeTitle)
   }
   static var uiTitle1: Font {
-    if #available(iOS 14, *) {
-      return Font.custom("Bitter-Bold", size: 28.0, relativeTo: .title)
-    } else {
-      return Font.custom("Bitter-Bold", size: 28.0)
-    }
+    Font.custom("Bitter-Bold", size: 28.0, relativeTo: .title)
   }
   static var uiTitle2: Font {
-    if #available(iOS 14, *) {
-      return Font.custom("Bitter-Bold", size: 23.0, relativeTo: .title2)
-    } else {
-      return Font.custom("Bitter-Bold", size: 23.0)
-    }
+    Font.custom("Bitter-Bold", size: 23.0, relativeTo: .title2)
   }
   static var uiTitle3: Font {
-    if #available(iOS 14, *) {
-      return Font.custom("Bitter-Bold", size: 20.0, relativeTo: .title3)
-    } else {
-      return Font.custom("Bitter-Bold", size: 20.0)
-    }
+    Font.custom("Bitter-Bold", size: 20.0, relativeTo: .title3)
   }
   static var uiTitle4: Font {
-    if #available(iOS 14, *) {
-      return Font.custom("Bitter-Bold", size: 19.0, relativeTo: .title3)
-    } else {
-      return Font.custom("Bitter-Bold", size: 19.0)
-    }
+    Font.custom("Bitter-Bold", size: 19.0, relativeTo: .title3)
   }
   static var uiTitle5: Font {
-    if #available(iOS 14, *) {
-      return Font.custom("Bitter-Regular", size: 17.0, relativeTo: .body)
-    } else {
-      return Font.custom("Bitter-Regular", size: 17.0)
-    }
+    Font.custom("Bitter-Regular", size: 17.0, relativeTo: .body)
   }
   static var uiHeadline: Font {
     Font.system(size: UIFontMetrics.default.scaledValue(for: 18.0)).weight(.semibold)
   }
   
   static var uiNumberBox: Font {
-    if #available(iOS 14, *) {
-      return Font.custom("Bitter-Bold", size: 13.0, relativeTo: .footnote)
-    } else {
-      return Font.custom("Bitter-Bold", size: 13.0)
-    }
+    Font.custom("Bitter-Bold", size: 13.0, relativeTo: .footnote)
   }
 
   static var uiBodyAppleDefault: Font {

--- a/Emitron/Emitron/Support Files/Base.lproj/LaunchScreen.storyboard
+++ b/Emitron/Emitron/Support Files/Base.lproj/LaunchScreen.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="15705" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15706"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -17,9 +17,10 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="logo" translatesAutoresizingMaskIntoConstraints="NO" id="ndi-dn-BBO">
-                                <rect key="frame" x="70" y="403" width="274" height="100"/>
+                                <rect key="frame" x="70" y="428" width="274" height="50"/>
                             </imageView>
                         </subviews>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
                         <color key="backgroundColor" name="backgroundColor"/>
                         <constraints>
                             <constraint firstAttribute="trailing" secondItem="ndi-dn-BBO" secondAttribute="trailing" constant="70" id="2Bk-2q-Poc"/>
@@ -27,7 +28,6 @@
                             <constraint firstItem="ndi-dn-BBO" firstAttribute="centerY" secondItem="6Tk-OE-BBY" secondAttribute="centerY" id="j1t-rx-dou"/>
                             <constraint firstItem="ndi-dn-BBO" firstAttribute="centerX" secondItem="6Tk-OE-BBY" secondAttribute="centerX" id="v6x-C1-10H"/>
                         </constraints>
-                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
                     </view>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder"/>
@@ -38,7 +38,7 @@
     <resources>
         <image name="logo" width="238" height="50"/>
         <namedColor name="backgroundColor">
-            <color red="0.94901960784313721" green="0.96470588235294119" blue="0.98039215686274506" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="0.94900000095367432" green="0.9649999737739563" blue="0.98000001907348633" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
     </resources>
 </document>

--- a/Emitron/Emitron/Support Files/Info.plist
+++ b/Emitron/Emitron/Support Files/Info.plist
@@ -170,20 +170,6 @@
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>
 		<false/>
-		<key>UISceneConfigurations</key>
-		<dict>
-			<key>UIWindowSceneSessionRoleApplication</key>
-			<array>
-				<dict>
-					<key>UILaunchStoryboardName</key>
-					<string>LaunchScreen</string>
-					<key>UISceneConfigurationName</key>
-					<string>Default Configuration</string>
-					<key>UISceneDelegateClassName</key>
-					<string>$(PRODUCT_MODULE_NAME).SceneDelegate</string>
-				</dict>
-			</array>
-		</dict>
 	</dict>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>

--- a/Emitron/Emitron/UI/App Root/MainView.swift
+++ b/Emitron/Emitron/UI/App Root/MainView.swift
@@ -32,6 +32,9 @@ import StoreKit
 struct MainView: View {
   @EnvironmentObject var sessionController: SessionController
   @EnvironmentObject var dataManager: DataManager
+  @EnvironmentObject var messageBus: MessageBus
+  @EnvironmentObject var settingsManager: SettingsManager
+
   private let tabViewModel = TabViewModel()
   private let notification = NotificationCenter.default.publisher(for: .requestReview)
 
@@ -39,7 +42,7 @@ struct MainView: View {
     ZStack {
       contentView
         .background(Color.backgroundColor)
-        .overlay(MessageBarView(messageBus: MessageBus.current), alignment: .bottom)
+        .overlay(MessageBarView(messageBus: messageBus), alignment: .bottom)
         .onReceive(notification) { _ in
           DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) {
             makeReviewRequest()
@@ -80,8 +83,7 @@ private extension MainView {
       contentScreen: .downloads(permitted: sessionController.user?.canDownload ?? false),
       downloadRepository: dataManager.downloadRepository
     )
-    
-    let settingsView = SettingsView()
+    let settingsView = SettingsView(settingsManager: settingsManager)
 
     switch sessionController.sessionState {
     case .online :

--- a/Emitron/Emitron/UI/App Root/MainView.swift
+++ b/Emitron/Emitron/UI/App Root/MainView.swift
@@ -52,12 +52,8 @@ struct MainView: View {
   }
 
   private func makeReviewRequest() {
-    if #available(iOS 14.0, *) {
-      if let scene = UIApplication.shared.connectedScenes.first(where: { $0.activationState == .foregroundActive }) as? UIWindowScene {
-        SKStoreReviewController.requestReview(in: scene)
-      }
-    } else {
-      SKStoreReviewController.requestReview()
+    if let scene = UIApplication.shared.connectedScenes.first(where: { $0.activationState == .foregroundActive }) as? UIWindowScene {
+      SKStoreReviewController.requestReview(in: scene)
     }
   }
 }

--- a/Emitron/Emitron/UI/App Root/MessageBarView.swift
+++ b/Emitron/Emitron/UI/App Root/MessageBarView.swift
@@ -58,18 +58,17 @@ struct MessageBarView_Previews: PreviewProvider {
     messageBus.post(message: Message(level: .warning, message: "This is a warning"))
     
     return VStack {
-      Button(action: {
+      Button {
         messageBus.messageVisible.toggle()
-      }) {
+      } label: {
         Text("Show/Hide")
       }
-      
-      Button(action: {
+
+      Button {
         messageBus.post(message: Message(level: .success, message: "Button clicked!"))
-      }) {
+      } label: {
         Text("Post new message")
       }
-      
       MessageBarView(messageBus: messageBus)
     }
   }

--- a/Emitron/Emitron/UI/App Root/SnackbarView.swift
+++ b/Emitron/Emitron/UI/App Root/SnackbarView.swift
@@ -64,16 +64,17 @@ struct SnackbarView: View {
         .animation(.none)
       
       Spacer()
-      
-      Button(action: {
+
+      Button {
         withAnimation {
           visible.toggle()
         }
-      }) {
+      } label: {
         Image.closeWhite
           .resizable()
           .frame(width: 18, height: 18)
-      }.foregroundColor(.snackText)
+      }
+      .foregroundColor(.snackText)
     }
     .padding()
     .background(state.status.color)

--- a/Emitron/Emitron/UI/App Root/TabNavView.swift
+++ b/Emitron/Emitron/UI/App Root/TabNavView.swift
@@ -35,6 +35,7 @@ struct TabNavView<
   SettingsView: View
 >: View {
   @EnvironmentObject var tabViewModel: TabViewModel
+  @EnvironmentObject var settingsManager: SettingsManager
   let libraryView: LibraryView
   let myTutorialsView: MyTutorialsView
   let downloadsView: DownloadsView

--- a/Emitron/Emitron/UI/Downloads/DownloadsView.swift
+++ b/Emitron/Emitron/UI/Downloads/DownloadsView.swift
@@ -29,6 +29,7 @@
 import SwiftUI
 
 struct DownloadsView: View {
+  @EnvironmentObject var downloadService: DownloadService
   @State var contentScreen: ContentScreen
   @ObservedObject var downloadRepository: DownloadRepository
 
@@ -39,7 +40,7 @@ struct DownloadsView: View {
 
   private var contentView: some View {
     ContentListView(contentRepository: downloadRepository,
-                    downloadAction: DownloadService.current,
+                    downloadAction: downloadService,
                     contentScreen: contentScreen)
   }
 }

--- a/Emitron/Emitron/UI/Empty States/LoadingView.swift
+++ b/Emitron/Emitron/UI/Empty States/LoadingView.swift
@@ -30,11 +30,16 @@ import SwiftUI
 
 struct LoadingView: View {
   var body: some View {
-    VStack {
-      ActivityIndicator()
-        .padding([.bottom], 10)
-      Text(String.loading)
-        .font(.uiHeadline)
+    ZStack {
+      Rectangle()
+        .fill(Color.backgroundColor)
+        .edgesIgnoringSafeArea(.all)
+      VStack {
+        ActivityIndicator()
+          .padding([.bottom], 10)
+        Text(String.loading)
+          .font(.uiHeadline)
+      }
     }
   }
 }

--- a/Emitron/Emitron/UI/Empty States/NoResultsView.swift
+++ b/Emitron/Emitron/UI/Empty States/NoResultsView.swift
@@ -46,38 +46,43 @@ struct NoResultsView<Header: View> {
 // MARK: - View
 extension NoResultsView: View {
   var body: some View {
-    VStack {
-      header
-      
-      Spacer()
+    ZStack {
+      Rectangle()
+        .fill(Color.backgroundColor)
+        .edgesIgnoringSafeArea(.all)
+      VStack {
+        header
 
-      Image(contentScreen.emptyImageName)
-        .padding([.bottom], 30)
+        Spacer()
 
-      Text(contentScreen.titleMessage)
-        .font(.uiTitle2)
-        .foregroundColor(.titleText)
-        .multilineTextAlignment(.center)
-        .padding([.bottom], 20)
-        .padding([.leading, .trailing], 20)
+        Image(contentScreen.emptyImageName)
+          .padding([.bottom], 30)
 
-      Text(contentScreen.detailMesage)
-        .lineSpacing(5)
-        .font(.uiLabel)
-        .foregroundColor(.contentText)
-        .multilineTextAlignment(.center)
-        .padding([.bottom], 20)
-        .padding([.leading, .trailing], 20)
-      
-      Spacer()
-      
-      if contentScreen.showExploreButton {
-        MainButtonView(
-          title: "Explore Tutorials",
-          type: .primary(withArrow: true)) {
-            tabViewModel.selectedTab = .library
+        Text(contentScreen.titleMessage)
+          .font(.uiTitle2)
+          .foregroundColor(.titleText)
+          .multilineTextAlignment(.center)
+          .padding([.bottom], 20)
+          .padding([.leading, .trailing], 20)
+
+        Text(contentScreen.detailMesage)
+          .lineSpacing(5)
+          .font(.uiLabel)
+          .foregroundColor(.contentText)
+          .multilineTextAlignment(.center)
+          .padding([.bottom], 20)
+          .padding([.leading, .trailing], 20)
+
+        Spacer()
+
+        if contentScreen.showExploreButton {
+          MainButtonView(
+            title: "Explore Tutorials",
+            type: .primary(withArrow: true)) {
+              tabViewModel.selectedTab = .library
+          }
+          .padding([.horizontal, .bottom], 20)
         }
-        .padding([.horizontal, .bottom], 20)
       }
     }
   }
@@ -85,12 +90,20 @@ extension NoResultsView: View {
 
 struct NoResultsView_Previews: PreviewProvider {
   static var previews: some View {
-    NoResultsView(contentScreen: .bookmarked)
-    NoResultsView(contentScreen: .completed)
-    NoResultsView(contentScreen: .downloads(permitted: true))
-    NoResultsView(contentScreen: .downloads(permitted: false))
-    NoResultsView(contentScreen: .inProgress)
-    NoResultsView(contentScreen: .library)
+    SwiftUI.Group {
+      NoResultsView(contentScreen: .bookmarked).colorScheme(.light)
+      NoResultsView(contentScreen: .bookmarked).colorScheme(.dark)
+      NoResultsView(contentScreen: .completed).colorScheme(.light)
+      NoResultsView(contentScreen: .completed).colorScheme(.dark)
+      NoResultsView(contentScreen: .downloads(permitted: true)).colorScheme(.light)
+      NoResultsView(contentScreen: .downloads(permitted: true)).colorScheme(.dark)
+      NoResultsView(contentScreen: .downloads(permitted: false)).colorScheme(.light)
+      NoResultsView(contentScreen: .downloads(permitted: false)).colorScheme(.dark)
+      NoResultsView(contentScreen: .inProgress).colorScheme(.light)
+      NoResultsView(contentScreen: .inProgress).colorScheme(.dark)
+    }
+    NoResultsView(contentScreen: .library).colorScheme(.light)
+    NoResultsView(contentScreen: .library).colorScheme(.dark)
   }
 }
 

--- a/Emitron/Emitron/UI/Empty States/OfflineView.swift
+++ b/Emitron/Emitron/UI/Empty States/OfflineView.swift
@@ -56,5 +56,6 @@ struct OfflineView: View {
 struct OfflineView_Previews: PreviewProvider {
   static var previews: some View {
     OfflineView()
+    OfflineView().colorScheme(.dark)
   }
 }

--- a/Emitron/Emitron/UI/Empty States/ReloadView.swift
+++ b/Emitron/Emitron/UI/Empty States/ReloadView.swift
@@ -44,40 +44,47 @@ struct ReloadView<Header: View> {
 // MARK: - View {
 extension ReloadView: View {
   var body: some View {
-    VStack {
-      header
-      
-      Spacer()
-      
-      Image("emojiCrying")
-        .padding(.bottom, 30)
-      
-      Text("Something went wrong.")
-        .font(.uiTitle2)
-        .foregroundColor(.titleText)
-        .multilineTextAlignment(.center)
-        .padding([.leading, .trailing, .bottom], 20)
-      
-      Text("Please try again.")
-        .lineSpacing(8)
-        .font(.uiLabel)
-        .foregroundColor(.contentText)
-        .multilineTextAlignment(.center)
-        .padding([.leading, .trailing], 20)
-      
-      Spacer()
-      
-      MainButtonView(
-        title: "Reload",
-        type: .primary(withArrow: false),
-        callback: reloadHandler)
-        .padding([.horizontal, .bottom], 20)
+    ZStack {
+      Rectangle()
+        .fill(Color.backgroundColor)
+        .edgesIgnoringSafeArea(.all)
+      VStack {
+        header
+        Spacer()
+
+        Image("emojiCrying")
+          .padding(.bottom, 30)
+
+        Text("Something went wrong.")
+          .font(.uiTitle2)
+          .foregroundColor(.titleText)
+          .multilineTextAlignment(.center)
+          .padding([.leading, .trailing, .bottom], 20)
+
+        Text("Please try again.")
+          .lineSpacing(8)
+          .font(.uiLabel)
+          .foregroundColor(.contentText)
+          .multilineTextAlignment(.center)
+          .padding([.leading, .trailing], 20)
+
+        Spacer()
+
+        MainButtonView(
+          title: "Reload",
+          type: .primary(withArrow: false),
+          callback: reloadHandler)
+          .padding([.horizontal, .bottom], 20)
+      }
     }
   }
 }
 
 struct ErrorView_Previews: PreviewProvider {
   static var previews: some View {
-    ReloadView(header: EmptyView(), reloadHandler: {})
+    SwiftUI.Group {
+      ReloadView(header: EmptyView(), reloadHandler: {}).colorScheme(.light)
+      ReloadView(header: EmptyView(), reloadHandler: {}).colorScheme(.dark)
+    }
   }
 }

--- a/Emitron/Emitron/UI/Library/Filtering/AppliedFilterTagButton.swift
+++ b/Emitron/Emitron/UI/Library/Filtering/AppliedFilterTagButton.swift
@@ -85,7 +85,9 @@ struct AppliedFilterTagButton: View {
   let removeFilterAction: () -> Void
   
   var body: some View {
-    Button(action: removeFilterAction) {
+    Button {
+      removeFilterAction()
+    } label: {
       HStack(spacing: 7) {
         Text(name)
           .foregroundColor(type.textColor)
@@ -95,12 +97,12 @@ struct AppliedFilterTagButton: View {
           .frame(width: Layout.imageSize, height: Layout.imageSize)
           .foregroundColor(type.iconColor)
       }
-        .padding(.all, Layout.Padding.overall)
-    .background(
-      RoundedRectangle(cornerRadius: Layout.cornerRadius)
-        .fill(type.backgroundColor)
-        .overlay(
-          RoundedRectangle(cornerRadius: Layout.cornerRadius)
+      .padding(.all, Layout.Padding.overall)
+      .background(
+        RoundedRectangle(cornerRadius: Layout.cornerRadius)
+          .fill(type.backgroundColor)
+          .overlay(
+            RoundedRectangle(cornerRadius: Layout.cornerRadius)
             .stroke(type.borderColor, lineWidth: 2)
         )
       )

--- a/Emitron/Emitron/UI/Library/Filtering/FiltersHeaderView.swift
+++ b/Emitron/Emitron/UI/Library/Filtering/FiltersHeaderView.swift
@@ -46,14 +46,14 @@ struct FiltersHeaderView: View {
   
   var body: some View {
     VStack {
-      Button(action: {
+      Button {
         isExpanded.toggle()
-      }) {
+      } label: {
         HStack {
           Text("\(filterGroup.type.name)\(filterCount)")
             .foregroundColor(.titleText)
             .font(.uiLabelBold)
-          
+
           Spacer()
 
           Image(systemName: isExpanded ? "chevron.up" : "chevron.down")
@@ -65,7 +65,7 @@ struct FiltersHeaderView: View {
         .background(Color.filterHeaderBackground)
         .cornerRadius(Layout.cornerRadius)
       }
-        .accessibility(label: Text(filterGroup.type.name))
+      .accessibility(label: Text(filterGroup.type.name))
         
       if isExpanded {
         expandedView

--- a/Emitron/Emitron/UI/Library/Filtering/FiltersHeaderView.swift
+++ b/Emitron/Emitron/UI/Library/Filtering/FiltersHeaderView.swift
@@ -114,12 +114,12 @@ struct FilterGroupView_Previews: PreviewProvider {
     return VStack {
       FiltersHeaderView(
         filterGroup: FilterGroup(type: .difficulties, filters: filters),
-        filters: Filters(),
+        filters: Filters(settingsManager: EmitronApp.emitronObjects().settingsManager),
         isExpanded: true
       )
       FiltersHeaderView(
         filterGroup: FilterGroup(type: .categories, filters: filters),
-        filters: Filters()
+        filters: Filters(settingsManager: EmitronApp.emitronObjects().settingsManager)
       )
     }
       .padding()

--- a/Emitron/Emitron/UI/Library/Filtering/FiltersView.swift
+++ b/Emitron/Emitron/UI/Library/Filtering/FiltersView.swift
@@ -50,13 +50,13 @@ struct FiltersView: View {
           .foregroundColor(.titleText)
         
         Spacer()
-        
-        Button(action: {
+
+        Button {
           if Set(libraryRepository.nonPaginationParameters) != Set(filters.appliedParameters) {
             revertBackToPreviousFilters()
           }
           presentationMode.wrappedValue.dismiss()
-        }) {
+        } label: {
           Image.close
             .frame(width: 27, height: 27, alignment: .center)
             .padding(.trailing, 18)

--- a/Emitron/Emitron/UI/Library/LibraryView.swift
+++ b/Emitron/Emitron/UI/Library/LibraryView.swift
@@ -36,6 +36,7 @@ private extension CGFloat {
 }
 
 struct LibraryView: View {
+  @EnvironmentObject private var downloadService: DownloadService
   @ObservedObject var filters: Filters
   @ObservedObject var libraryRepository: LibraryRepository
   @State var filtersPresented = false
@@ -159,7 +160,7 @@ struct LibraryView: View {
   private var contentView: some View {
     ContentListView(
       contentRepository: libraryRepository,
-      downloadAction: DownloadService.current,
+      downloadAction: downloadService,
       contentScreen: .library,
       header: contentControlsSection
     )

--- a/Emitron/Emitron/UI/Library/LibraryView.swift
+++ b/Emitron/Emitron/UI/Library/LibraryView.swift
@@ -81,15 +81,15 @@ struct LibraryView: View {
       
       Spacer()
 
-      Button(action: {
+      Button {
         filtersPresented = true
-      }, label: {
+      } label: {
         Image("filter")
           .foregroundColor(.iconButton)
           .frame(width: .filterButtonSide, height: .filterButtonSide)
-      })
-        .accessibility(label: Text("Filter Library"))
-        .padding([.horizontal], .searchFilterPadding)
+      }
+      .accessibility(label: Text("Filter Library"))
+      .padding([.horizontal], .searchFilterPadding)
     }
   }
 
@@ -101,7 +101,9 @@ struct LibraryView: View {
 
       Spacer()
 
-      Button(action: changeSort) {
+      Button {
+        changeSort()
+      } label: {
         HStack {
           Image("sort")
             .foregroundColor(.textButtonText)

--- a/Emitron/Emitron/UI/Library/SearchFieldView.swift
+++ b/Emitron/Emitron/UI/Library/SearchFieldView.swift
@@ -56,10 +56,10 @@ struct SearchFieldView: View {
         .contentShape(Rectangle())
       
       if !searchString.isEmpty {
-        Button(action: {
+        Button {
           searchString = ""
           action(searchString)
-        }) {
+        } label: {
           Image(systemName: "multiply.circle.fill")
             // If we don't enforce a frame, the button doesn't register the tap action
             .frame(width: 25, height: 25, alignment: .center)

--- a/Emitron/Emitron/UI/My Tutorials/MyTutorialsView.swift
+++ b/Emitron/Emitron/UI/My Tutorials/MyTutorialsView.swift
@@ -78,6 +78,7 @@ struct MyTutorialView {
   // I think this is a bug.
   @EnvironmentObject private var sessionController: SessionController
   @EnvironmentObject private var tabViewModel: TabViewModel
+  @EnvironmentObject private var downloadService: DownloadService
   
   private let inProgressRepository: InProgressRepository
   private let completedRepository: CompletedRepository
@@ -157,7 +158,7 @@ private extension MyTutorialView {
     
     return ContentListView(
       contentRepository: contentRepository,
-      downloadAction: DownloadService.current,
+      downloadAction: downloadService,
       contentScreen: ContentScreen.inProgress,
       header: toggleControl
     )

--- a/Emitron/Emitron/UI/My Tutorials/ToggleControlView.swift
+++ b/Emitron/Emitron/UI/My Tutorials/ToggleControlView.swift
@@ -49,13 +49,12 @@ struct ToggleControlView: View {
   }
   
   private func toggleButton(for state: MyTutorialsState) -> some View {
-    Button(action: {
+    Button {
       guard state != toggleState else { return }
-      
       toggleState = state
       toggleUpdated?(state)
       messageBus.dismiss()
-    }) {
+    } label: {
       toggleButtonContent(for: state)
     }
   }

--- a/Emitron/Emitron/UI/My Tutorials/ToggleControlView.swift
+++ b/Emitron/Emitron/UI/My Tutorials/ToggleControlView.swift
@@ -30,6 +30,8 @@ import SwiftUI
 
 struct ToggleControlView: View {
   @State var toggleState: MyTutorialsState
+  @EnvironmentObject var messageBus: MessageBus
+
   var toggleUpdated: ((MyTutorialsState) -> Void)?
   
   var body: some View {
@@ -52,7 +54,7 @@ struct ToggleControlView: View {
       
       toggleState = state
       toggleUpdated?(state)
-      MessageBus.current.dismiss()
+      messageBus.dismiss()
     }) {
       toggleButtonContent(for: state)
     }

--- a/Emitron/Emitron/UI/SceneDelegate.swift
+++ b/Emitron/Emitron/UI/SceneDelegate.swift
@@ -61,27 +61,26 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     UISwitch.appearance().onTintColor = .accent
     
     // Use a UIHostingController as window root view controller
-    if let windowScene = scene as? UIWindowScene {
-      let window = UIWindow(windowScene: windowScene)
-      
+//    if let windowScene = scene as? UIWindowScene {
+//      let window = UIWindow(windowScene: windowScene)
       // We grab this from the App Delegate, since it's needed there too
-      let sessionController = SessionController.current
-      let dataManager = DataManager.current
-      let mainView = MainView()
-        .environmentObject(sessionController)
-        .environmentObject(dataManager)
-      if NSUbiquitousKeyValueStore.default.object(forKey: LookupKey.requestReview) == nil {
-        NSUbiquitousKeyValueStore.default.set(Date().timeIntervalSince1970, forKey: LookupKey.requestReview)
-      }
-
-      window.rootViewController = PortraitHostingController(rootView: mainView)
-      self.window = window
-      window.rootViewController?.view.backgroundColor = .backgroundColor
-      // TODO: When a modifier is available this should be refactored
-      window.tintColor = .accent
-      
-      window.makeKeyAndVisible()
-    }
+//      let sessionController = SessionController.current
+//      let dataManager = DataManager.current
+//      let mainView = MainView()
+//        .environmentObject(sessionController)
+//        .environmentObject(dataManager)
+//      if NSUbiquitousKeyValueStore.default.object(forKey: LookupKey.requestReview) == nil {
+//        NSUbiquitousKeyValueStore.default.set(Date().timeIntervalSince1970, forKey: LookupKey.requestReview)
+//      }
+//
+//      window.rootViewController = PortraitHostingController(rootView: mainView)
+//      self.window = window
+//      window.rootViewController?.view.backgroundColor = .backgroundColor
+//      // TODO: When a modifier is available this should be refactored
+//      window.tintColor = .accent
+//      
+//      window.makeKeyAndVisible()
+//
   }
 
   func sceneDidDisconnect(_ scene: UIScene) {
@@ -103,7 +102,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
   func sceneWillEnterForeground(_ scene: UIScene) {
     // Request Permissions if necessary
-    SessionController.current.fetchPermissionsIfNeeded()
+    // SessionController.current.fetchPermissionsIfNeeded()
   }
 
   func sceneDidEnterBackground(_ scene: UIScene) {

--- a/Emitron/Emitron/UI/SceneDelegate.swift
+++ b/Emitron/Emitron/UI/SceneDelegate.swift
@@ -59,28 +59,6 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     ]
     
     UISwitch.appearance().onTintColor = .accent
-    
-    // Use a UIHostingController as window root view controller
-//    if let windowScene = scene as? UIWindowScene {
-//      let window = UIWindow(windowScene: windowScene)
-      // We grab this from the App Delegate, since it's needed there too
-//      let sessionController = SessionController.current
-//      let dataManager = DataManager.current
-//      let mainView = MainView()
-//        .environmentObject(sessionController)
-//        .environmentObject(dataManager)
-//      if NSUbiquitousKeyValueStore.default.object(forKey: LookupKey.requestReview) == nil {
-//        NSUbiquitousKeyValueStore.default.set(Date().timeIntervalSince1970, forKey: LookupKey.requestReview)
-//      }
-//
-//      window.rootViewController = PortraitHostingController(rootView: mainView)
-//      self.window = window
-//      window.rootViewController?.view.backgroundColor = .backgroundColor
-//      // TODO: When a modifier is available this should be refactored
-//      window.tintColor = .accent
-//      
-//      window.makeKeyAndVisible()
-//
   }
 
   func sceneDidDisconnect(_ scene: UIScene) {

--- a/Emitron/Emitron/UI/Settings/Icons/IconChooserView.swift
+++ b/Emitron/Emitron/UI/Settings/Icons/IconChooserView.swift
@@ -29,7 +29,7 @@
 import SwiftUI
 
 struct IconChooserView: View {
-  @ObservedObject var iconManager = IconManager.current
+  @EnvironmentObject var iconManager: IconManager
   
   var body: some View {
     HStack {

--- a/Emitron/Emitron/UI/Settings/Icons/IconChooserView.swift
+++ b/Emitron/Emitron/UI/Settings/Icons/IconChooserView.swift
@@ -34,9 +34,9 @@ struct IconChooserView: View {
   var body: some View {
     HStack {
       ForEach(iconManager.icons) { icon in
-        Button(action: {
+        Button {
           iconManager.set(icon: icon)
-        }) {
+        } label: {
           IconView(icon: icon, selected: iconManager.currentIcon == icon)
         }
       }

--- a/Emitron/Emitron/UI/Settings/Licenses/LicenseListView.swift
+++ b/Emitron/Emitron/UI/Settings/Licenses/LicenseListView.swift
@@ -56,9 +56,9 @@ struct LicenseListView: View {
   }
   
   var dismissButton: some View {
-    Button(action: {
+    Button {
       visible.toggle()
-    }) {
+    } label: {
       Image.close
         .foregroundColor(.iconButton)
     }

--- a/Emitron/Emitron/UI/Settings/SettingsList.swift
+++ b/Emitron/Emitron/UI/Settings/SettingsList.swift
@@ -49,7 +49,7 @@ struct SettingsList_Previews: PreviewProvider {
   }
 
   static var list: some View {
-    SettingsList(settingsManager: .init(initialValue: .current), canDownload: true)
+    SettingsList(settingsManager: .init(initialValue: EmitronApp.emitronObjects().settingsManager), canDownload: true)
       .background(Color.backgroundColor)
   }
 }

--- a/Emitron/Emitron/UI/Settings/SettingsSelectionView.swift
+++ b/Emitron/Emitron/UI/Settings/SettingsSelectionView.swift
@@ -36,24 +36,23 @@ struct SettingsSelectionView<Setting: SettingsSelectable>: View {
     VStack(spacing: 0) {
       ForEach(type(of: settingsOption).selectableCases, id: \.self) { option in
         VStack(spacing: 0) {
-          Button(action: {
+          Button {
             settingsOption = option
-          }) {
+          } label: {
             HStack {
               Text(option.display)
                 .font(.uiBodyAppleDefault)
                 .foregroundColor(.titleText)
                 .padding([.vertical], SettingsLayout.rowSpacing)
-            
+
               Spacer()
-              
+
               if option == settingsOption {
                 Image.checkmark
                   .foregroundColor(.iconButton)
               }
             }
           }
-          
           Rectangle()
             .fill(Color.separator)
             .frame(height: 1)

--- a/Emitron/Emitron/UI/Settings/SettingsView.swift
+++ b/Emitron/Emitron/UI/Settings/SettingsView.swift
@@ -66,16 +66,16 @@ struct SettingsView: View {
         .padding([.horizontal], 20)
         
         Spacer()
-        
-        Button(action: {
+
+        Button {
           licensesPresented.toggle()
-        }) {
+        } label: {
           Text("Software Licenses")
         }
-          .sheet(isPresented: $licensesPresented) {
+        .sheet(isPresented: $licensesPresented) {
             LicenseListView(visible: $licensesPresented)
-          }
-          .padding([.bottom], 25)
+        }
+        .padding([.bottom], 25)
         
           VStack {
             if sessionController.user != nil {

--- a/Emitron/Emitron/UI/Settings/SettingsView.swift
+++ b/Emitron/Emitron/UI/Settings/SettingsView.swift
@@ -37,8 +37,12 @@ enum SettingsLayout {
 struct SettingsView: View {
   @EnvironmentObject var sessionController: SessionController
   @EnvironmentObject var tabViewModel: TabViewModel
-  @ObservedObject private var settingsManager = SettingsManager.current
+  @ObservedObject private var settingsManager: SettingsManager
   @State private var licensesPresented = false
+
+  init(settingsManager: SettingsManager) {
+    self.settingsManager = settingsManager
+  }
   
   var body: some View {
       VStack {
@@ -94,6 +98,7 @@ struct SettingsView: View {
 
 #if DEBUG
 struct SettingsView_Previews: PreviewProvider {
+
   static var previews: some View {
     SwiftUI.Group {
       settingsView.colorScheme(.dark)
@@ -102,9 +107,9 @@ struct SettingsView_Previews: PreviewProvider {
   }
 
   static var settingsView: some View {
-    SettingsView()
+    SettingsView(settingsManager: EmitronApp.emitronObjects().settingsManager)
       .background(Color.backgroundColor)
-      .environmentObject(SessionController.current)
+      .environmentObject(EmitronApp.emitronObjects().sessionController)
   }
 }
 #endif

--- a/Emitron/Emitron/UI/Shared/CheckmarkView.swift
+++ b/Emitron/Emitron/UI/Shared/CheckmarkView.swift
@@ -42,17 +42,16 @@ struct CheckmarkView: View {
   var onChange: (Bool) -> Void
   
   var body: some View {
-        
-    Button(action: {
+    Button {
       onChange(!isOn)
-    }) {
+    } label: {
       if isOn {
         ZStack(alignment: .center) {
           Rectangle()
 
             .frame(maxWidth: outerSide, maxHeight: outerSide)
             .foregroundColor(.checkmarkBackground)
-          
+
           Image.checkmark
             .resizable()
             .frame(maxWidth: innerSide - 1, maxHeight: innerSide + 1)

--- a/Emitron/Emitron/UI/Shared/Content Detail/ChildContentListingView.swift
+++ b/Emitron/Emitron/UI/Shared/Content Detail/ChildContentListingView.swift
@@ -32,6 +32,7 @@ struct ChildContentListingView: View {
   @ObservedObject var childContentsViewModel: ChildContentsViewModel
   @Binding var currentlyDisplayedVideoPlaybackViewModel: VideoPlaybackViewModel?
   @EnvironmentObject var sessionController: SessionController
+  @EnvironmentObject var messageBus: MessageBus
   
   var body: some View {
     childContentsViewModel.initialiseIfRequired()
@@ -138,8 +139,7 @@ private extension ChildContentListingView {
       .padding([.horizontal, .bottom], 20)
     } else if sessionController.sessionState == .offline && !sessionController.hasCurrentDownloadPermissions {
       Button(action: {
-        MessageBus.current
-          .post(message: Message(level: .warning, message: .videoPlaybackExpiredPermissions))
+        messageBus.post(message: Message(level: .warning, message: .videoPlaybackExpiredPermissions))
       }) {
         TextListItemView(
           dynamicContentViewModel: childDynamicContentViewModel,

--- a/Emitron/Emitron/UI/Shared/Content Detail/ChildContentListingView.swift
+++ b/Emitron/Emitron/UI/Shared/Content Detail/ChildContentListingView.swift
@@ -73,19 +73,11 @@ private extension ChildContentListingView {
       if childContentsViewModel.groups.count > 1 {
         ForEach(childContentsViewModel.groups, id: \.id) { group in
           // By default, iOS 14 shows headers in upper case. Text casing is changed by the textCase modifier which is not available on previous versions.
-          if #available(iOS 14, *) {
-            Section(header: CourseHeaderView(name: group.name)) {
-              episodeListing(data: childContentsViewModel.contents(for: group.id))
-            }
-            .background(Color.backgroundColor)
-            .textCase(nil)
-          } else {
-            // Default behavior for iOS 13 and lower.
-            Section(header: CourseHeaderView(name: group.name)) {
-              episodeListing(data: childContentsViewModel.contents(for: group.id))
-            }
-            .background(Color.backgroundColor)
+          Section(header: CourseHeaderView(name: group.name)) {
+            episodeListing(data: childContentsViewModel.contents(for: group.id))
           }
+          .background(Color.backgroundColor)
+          .textCase(nil)
         }
       } else if !childContentsViewModel.groups.isEmpty {
         episodeListing(data: childContentsViewModel.contents)

--- a/Emitron/Emitron/UI/Shared/Content Detail/ChildContentListingView.swift
+++ b/Emitron/Emitron/UI/Shared/Content Detail/ChildContentListingView.swift
@@ -130,9 +130,9 @@ private extension ChildContentListingView {
       )
       .padding([.horizontal, .bottom], 20)
     } else if sessionController.sessionState == .offline && !sessionController.hasCurrentDownloadPermissions {
-      Button(action: {
+      Button {
         messageBus.post(message: Message(level: .warning, message: .videoPlaybackExpiredPermissions))
-      }) {
+      } label: {
         TextListItemView(
           dynamicContentViewModel: childDynamicContentViewModel,
           content: model
@@ -140,14 +140,14 @@ private extension ChildContentListingView {
         .padding([.horizontal, .bottom], 20)
       }
     } else {
-      Button(action: {
+      Button {
         currentlyDisplayedVideoPlaybackViewModel = childDynamicContentViewModel.videoPlaybackViewModel(
           apiClient: sessionController.client,
           dismissClosure: {
             currentlyDisplayedVideoPlaybackViewModel = nil
           }
         )
-      }) {
+      } label: {
         TextListItemView(
           dynamicContentViewModel: childDynamicContentViewModel,
           content: model

--- a/Emitron/Emitron/UI/Shared/Content Detail/ContentDetailView.swift
+++ b/Emitron/Emitron/UI/Shared/Content Detail/ContentDetailView.swift
@@ -45,6 +45,7 @@ struct ContentDetailView {
   @ObservedObject private var dynamicContentViewModel: DynamicContentViewModel
 
   @EnvironmentObject private var sessionController: SessionController
+  @EnvironmentObject private var messageBus: MessageBus
 
   @State private var currentlyDisplayedVideoPlaybackViewModel: VideoPlaybackViewModel?
   private let videoCompletedNotification = NotificationCenter.default.publisher(for: .AVPlayerItemDidPlayToEndTime)
@@ -57,7 +58,7 @@ extension ContentDetailView: View {
       contentView
       
       if currentlyDisplayedVideoPlaybackViewModel != nil {
-        FullScreenVideoPlayerRepresentable(viewModel: $currentlyDisplayedVideoPlaybackViewModel)
+        FullScreenVideoPlayerRepresentable(viewModel: $currentlyDisplayedVideoPlaybackViewModel, messageBus: messageBus)
       }
     }
   }

--- a/Emitron/Emitron/UI/Shared/Content Detail/ContentDetailView.swift
+++ b/Emitron/Emitron/UI/Shared/Content Detail/ContentDetailView.swift
@@ -115,14 +115,14 @@ private extension ContentDetailView {
   var maxImageHeight: CGFloat { 384 }
   
   var continueOrPlayButton: some View {
-    Button(action: {
+    Button {
       currentlyDisplayedVideoPlaybackViewModel = dynamicContentViewModel.videoPlaybackViewModel(
         apiClient: sessionController.client,
         dismissClosure: {
           currentlyDisplayedVideoPlaybackViewModel = nil
         }
       )
-    }) {
+    } label: {
       if case .hasData = childContentsViewModel.state {
         if case .inProgress = dynamicContentViewModel.viewProgress {
           ContinueButtonView()

--- a/Emitron/Emitron/UI/Shared/Content List/ContentListView.swift
+++ b/Emitron/Emitron/UI/Shared/Content List/ContentListView.swift
@@ -48,6 +48,7 @@ struct ContentListView<Header: View> {
   private let header: Header
 
   @State private var deleteSubscriptions: Set<AnyCancellable> = []
+  @EnvironmentObject private var messageBus: MessageBus
 }
 
 // MARK: - View
@@ -235,10 +236,10 @@ private extension ContentListView {
             Failure
               .downloadAction(from: String(describing: type(of: self)), reason: "Unable to perform download action: \(error)")
               .log()
-            MessageBus.current.post(message: Message(level: .error, message: error.localizedDescription))
+            self.messageBus.post(message: Message(level: .error, message: error.localizedDescription))
           }
-        }) { _ in
-          MessageBus.current.post(message: Message(level: .success, message: .downloadDeleted))
+        }) {  _ in
+          self.messageBus.post(message: Message(level: .success, message: .downloadDeleted))
         }
         .store(in: &deleteSubscriptions)
     }

--- a/Emitron/Emitron/UI/Shared/Content List/ContentListView.swift
+++ b/Emitron/Emitron/UI/Shared/Content List/ContentListView.swift
@@ -136,14 +136,8 @@ private extension ContentListView {
   
   var listView: some View {
     List {
-      if #available(iOS 14, *) {
-        makeSectionList {
-          listContentView
-        }
-      } else {
-        makeList {
-          listContentView
-        }
+      makeSectionList {
+        listContentView
       }
     }
       .if(!allowDelete) {

--- a/Emitron/Emitron/UI/Shared/MainButtonView.swift
+++ b/Emitron/Emitron/UI/Shared/MainButtonView.swift
@@ -67,9 +67,9 @@ struct MainButtonView: View {
   var callback: () -> Void
   
   var body: some View {
-    Button(action: {
+    Button {
       callback()
-    }) {
+    } label: {
       HStack {
         ZStack(alignment: .center) {
           HStack {

--- a/Emitron/Emitron/UI/Video/FullScreenVideoPlayerRepresentable.swift
+++ b/Emitron/Emitron/UI/Video/FullScreenVideoPlayerRepresentable.swift
@@ -30,9 +30,10 @@ import SwiftUI
 
 struct FullScreenVideoPlayerRepresentable: UIViewControllerRepresentable {
   @Binding var viewModel: VideoPlaybackViewModel?
-  
+  let messageBus: MessageBus
+
   func makeUIViewController(context: UIViewControllerRepresentableContext<FullScreenVideoPlayerRepresentable>) -> FullScreenVideoPlayerViewController {
-    .init(viewModel: $viewModel)
+    .init(viewModel: $viewModel, messageBus: messageBus)
   }
   
   func updateUIViewController(_ uiViewController: FullScreenVideoPlayerViewController, context: UIViewControllerRepresentableContext<FullScreenVideoPlayerRepresentable>) {

--- a/Emitron/Emitron/UI/Video/FullScreenVideoPlayerViewController.swift
+++ b/Emitron/Emitron/UI/Video/FullScreenVideoPlayerViewController.swift
@@ -33,9 +33,11 @@ import SwiftUI
 class FullScreenVideoPlayerViewController: UIViewController {
   @Binding var viewModel: VideoPlaybackViewModel?
   private var isFullscreen = false
+  private let messageBus: MessageBus
   
-  init(viewModel: Binding<VideoPlaybackViewModel?>) {
+  init(viewModel: Binding<VideoPlaybackViewModel?>, messageBus: MessageBus) {
     _viewModel = viewModel
+    self.messageBus = messageBus
     super.init(nibName: nil, bundle: nil)
     
     self.viewModel?.reloadIfRequired()
@@ -66,7 +68,7 @@ extension FullScreenVideoPlayerViewController {
       try viewModel?.verifyCanPlay()
     } catch {
       if let viewModelError = error as? VideoPlaybackViewModel.Error {
-        MessageBus.current.post(
+        messageBus.post(
           message: Message(
             level: viewModelError.messageLevel,
             message: viewModelError.localizedDescription,

--- a/Emitron/emitronTests/Downloads/DownloadProcessorTest.swift
+++ b/Emitron/emitronTests/Downloads/DownloadProcessorTest.swift
@@ -36,6 +36,6 @@ class DownloadProcessorTest: XCTestCase {
   
   override func setUp() {
     super.setUp()
-    downloadProcessor = DownloadProcessor()
+    downloadProcessor = DownloadProcessor(settingsManager: EmitronApp.emitronObjects().settingsManager)
   }
 }

--- a/Emitron/emitronTests/Downloads/DownloadQueueManagerTest.swift
+++ b/Emitron/emitronTests/Downloads/DownloadQueueManagerTest.swift
@@ -207,7 +207,7 @@ class DownloadQueueManagerTest: XCTestCase {
     let download2 = try samplePersistedDownload(state: .enqueued)
     _ = try samplePersistedDownload(state: .enqueued)
     
-    let queue = try wait(for: recorder.next(4), timeout: 15)
+    let queue = try wait(for: recorder.next(4), timeout: 30)
     XCTAssertEqual([
       [],                     // Empty to start
       [download1],            // d1 Enqueued

--- a/Emitron/emitronTests/Downloads/DownloadQueueManagerTest.swift
+++ b/Emitron/emitronTests/Downloads/DownloadQueueManagerTest.swift
@@ -43,7 +43,6 @@ class DownloadQueueManagerTest: XCTestCase {
   override func setUp() {
     super.setUp()
 
-
     // There's one already running—let's stop that
     if downloadService != nil {
       downloadService.stopProcessing()

--- a/Emitron/emitronTests/Downloads/DownloadServiceTest.swift
+++ b/Emitron/emitronTests/Downloads/DownloadServiceTest.swift
@@ -36,6 +36,7 @@ class DownloadServiceTest: XCTestCase {
   private var videoService = VideosServiceMock()
   private var downloadService: DownloadService!
   private var userModelController: UserMCMock!
+  private var settingsManager: SettingsManager!
   
   override func setUp() {
     super.setUp()
@@ -43,9 +44,11 @@ class DownloadServiceTest: XCTestCase {
     database = try! EmitronDatabase.testDatabase()
     persistenceStore = PersistenceStore(db: database)
     userModelController = .init(user: .withDownloads)
+    settingsManager = EmitronApp.emitronObjects().settingsManager
     downloadService = DownloadService(persistenceStore: persistenceStore,
                                       userModelController: userModelController,
-                                      videosServiceProvider: { _ in self.videoService })
+                                      videosServiceProvider: { _ in self.videoService },
+                                      settingsManager: settingsManager)
     
     // Check it's all empty
     XCTAssertEqual(0, getAllContents().count)
@@ -56,7 +59,7 @@ class DownloadServiceTest: XCTestCase {
     super.tearDown()
     videoService.reset()
     deleteSampleFile(fileManager: FileManager.default)
-    SettingsManager.current.resetAll()
+    EmitronApp.emitronObjects().settingsManager.resetAll()
   }
   
   func getAllContents() -> [Content] {
@@ -463,7 +466,8 @@ class DownloadServiceTest: XCTestCase {
     userModelController.user = .none
     downloadService = DownloadService(persistenceStore: persistenceStore,
                                       userModelController: userModelController,
-                                      videosServiceProvider: { _ in self.videoService })
+                                      videosServiceProvider: { _ in self.videoService },
+                                      settingsManager: EmitronApp.emitronObjects().settingsManager)
     
     XCTAssert(!fileManager.fileExists(atPath: sampleFile.path))
   }
@@ -484,9 +488,11 @@ class DownloadServiceTest: XCTestCase {
     let sampleFile = createSampleFile(fileManager: fileManager)
     
     userModelController.user = .noPermissions
+
     downloadService = DownloadService(persistenceStore: persistenceStore,
                                       userModelController: userModelController,
-                                      videosServiceProvider: { _ in self.videoService })
+                                      videosServiceProvider: { _ in self.videoService },
+                                      settingsManager: EmitronApp.emitronObjects().settingsManager)
     
     XCTAssert(!fileManager.fileExists(atPath: sampleFile.path))
   }


### PR DESCRIPTION
This PR does a major refactor of the Emitron, removing iOS 13 support. The major point of this refactor moves the vast majority of the App Delegate to the EmitronApp struct. From there, the central objects that comprise Emitron are passed into the app by way of environment variables. This means each SwiftUI view is updated to use environment variables and some classes were updated to take in objects versus calling a singleton property.

The PR also removes if directives for iOS 13 since the minimal assumption is iOS 14. Previews and tests were also updated to use this new structure. 

This is a pretty major refactor with a lot of files changed. I imagine it's going to take some time for this to be reviewed. The best place to start is the new EmitronApp struct and work from there.