### PR TITLE
Underscore Clean Up

### DIFF
--- a/Emitron/Emitron/Data Synchronisation/ProgressEngine.swift
+++ b/Emitron/Emitron/Data Synchronisation/ProgressEngine.swift
@@ -155,7 +155,7 @@ final class ProgressEngine {
     }
   }
   
-  private func updateCacheWithProgress(for contentId: Int, progress: Int, target: Int? = nil) -> Progression {
+  @discardableResult private func updateCacheWithProgress(for contentId: Int, progress: Int, target: Int? = nil) -> Progression {
     let content = repository.content(for: contentId)
     let progression: Progression
     
@@ -180,10 +180,7 @@ final class ProgressEngine {
     if progression.finished,
       let parentContent = repository.parentContent(for: contentId),
       let childProgress = repository.childProgress(for: parentContent.id) {
-      
-      _ = updateCacheWithProgress(for: parentContent.id,
-                                  progress: childProgress.completed,
-                                  target: childProgress.total)
+      updateCacheWithProgress(for: parentContent.id, progress: childProgress.completed, target: childProgress.total)
     }
     
     return progression

--- a/Emitron/emitronTests/Downloads/DownloadQueueManagerTest.swift
+++ b/Emitron/emitronTests/Downloads/DownloadQueueManagerTest.swift
@@ -114,7 +114,7 @@ class DownloadQueueManagerTest: XCTestCase {
     return getAllDownloads().first!
   }
   
-  func samplePersistedDownload(state: Download.State = .pending) throws -> Download {
+  @discardableResult func samplePersistedDownload(state: Download.State = .pending) throws -> Download {
     try database.write { db in
       let content = PersistenceMocks.content
       try content.save(db)
@@ -212,7 +212,7 @@ class DownloadQueueManagerTest: XCTestCase {
   func testDownloadQueueStreamSendsFromThePast() throws {
     let download1 = try samplePersistedDownload(state: .enqueued)
     let download2 = try samplePersistedDownload(state: .enqueued)
-    _ = try samplePersistedDownload(state: .enqueued)
+    try samplePersistedDownload(state: .enqueued)
     
     let recorder = queueManager.downloadQueue.record()
     let queue = try wait(for: recorder.next(), timeout: 5)
@@ -220,9 +220,9 @@ class DownloadQueueManagerTest: XCTestCase {
   }
   
   func testDownloadQueueStreamSendsInProgressFirst() throws {
-    _ = try samplePersistedDownload(state: .enqueued)
+    try samplePersistedDownload(state: .enqueued)
     let download2 = try samplePersistedDownload(state: .inProgress)
-    _ = try samplePersistedDownload(state: .enqueued)
+    try samplePersistedDownload(state: .enqueued)
     let download4 = try samplePersistedDownload(state: .inProgress)
     
     let recorder = queueManager.downloadQueue.record()
@@ -233,7 +233,7 @@ class DownloadQueueManagerTest: XCTestCase {
   func testDownloadQueueStreamUpdatesWhenInProgressCompleted() throws {
     let download1 = try samplePersistedDownload(state: .enqueued)
     var download2 = try samplePersistedDownload(state: .inProgress)
-    _ = try samplePersistedDownload(state: .enqueued)
+    try samplePersistedDownload(state: .enqueued)
     let download4 = try samplePersistedDownload(state: .inProgress)
     
     let recorder = queueManager.downloadQueue.record()
@@ -257,7 +257,7 @@ class DownloadQueueManagerTest: XCTestCase {
     var queue = try wait(for: recorder.next(), timeout: 5)
     XCTAssertEqual([download1, download2], queue.map(\.download))
     
-    _ = try samplePersistedDownload(state: .enqueued)
+    try samplePersistedDownload(state: .enqueued)
     queue = try wait(for: recorder.next(), timeout: 5)
     XCTAssertEqual([download1, download2], queue.map(\.download))
   }

--- a/Emitron/emitronTests/Persistence/Models/PersistenceMocks.swift
+++ b/Emitron/emitronTests/Persistence/Models/PersistenceMocks.swift
@@ -50,7 +50,7 @@ enum PersistenceMocks {
             ordinal: 0)
   }
   
-  static func download(for content: Content) -> Download {
+  @discardableResult static func download(for content: Content) -> Download {
     Download(id: UUID(),
              requestedAt: Date(),
              state: .pending,

--- a/Emitron/emitronTests/Persistence/PersistenceStore+DownloadsTest.swift
+++ b/Emitron/emitronTests/Persistence/PersistenceStore+DownloadsTest.swift
@@ -225,7 +225,7 @@ class PersistenceStore_DownloadsTest: XCTestCase {
     let collection = try populateSampleCollection()
     let episodes = getAllContents().filter { $0.id != collection.id }
     
-    _ = PersistenceMocks.download(for: collection)
+    PersistenceMocks.download(for: collection)
     let episodeDownloads = episodes.map(PersistenceMocks.download)
     
     try database.write { db in
@@ -253,7 +253,7 @@ class PersistenceStore_DownloadsTest: XCTestCase {
     let collection = try populateSampleCollection()
     let episodes = getAllContents().filter { $0.id != collection.id }
     
-    _ = PersistenceMocks.download(for: collection)
+    PersistenceMocks.download(for: collection)
     let episodeDownloads = episodes[0..<10].map(PersistenceMocks.download)
     
     try database.write { db in
@@ -281,7 +281,7 @@ class PersistenceStore_DownloadsTest: XCTestCase {
     let collection = try populateSampleCollection()
     let episodes = getAllContents().filter { $0.id != collection.id }
     
-    _ = PersistenceMocks.download(for: collection)
+    PersistenceMocks.download(for: collection)
     let episodeDownloads = episodes[0..<10].map(PersistenceMocks.download)
     
     try database.write { db in
@@ -309,7 +309,7 @@ class PersistenceStore_DownloadsTest: XCTestCase {
     let collection = try populateSampleCollection()
     let episodes = getAllContents().filter { $0.id != collection.id }
     
-    _ = PersistenceMocks.download(for: collection)
+    PersistenceMocks.download(for: collection)
     let episodeDownloads = episodes.map(PersistenceMocks.download)
     
     try database.write { db in


### PR DESCRIPTION
Applied `@discardableResult` to functions where the result of the function is mostly or nearly not used to improve readability and keep code clean. 