### PR TITLE
Replaced colorScheme with preferredColorScheme

### DIFF
--- a/Emitron/Emitron/UI/Empty States/LoadingView.swift
+++ b/Emitron/Emitron/UI/Empty States/LoadingView.swift
@@ -42,8 +42,8 @@ struct LoadingView: View {
 struct LoadingView_Previews: PreviewProvider {
   static var previews: some View {
     SwiftUI.Group {
-      LoadingView().colorScheme(.dark)
-      LoadingView().colorScheme(.light)
+      LoadingView().preferredColorScheme(.dark)
+      LoadingView().preferredColorScheme(.light)
     }
   }
 }

--- a/Emitron/Emitron/UI/Generic/PagingIndicatorView.swift
+++ b/Emitron/Emitron/UI/Generic/PagingIndicatorView.swift
@@ -47,8 +47,8 @@ struct PagingIndicatorView: View {
 struct PagingIndicatorView_Previews: PreviewProvider {
   static var previews: some View {
     SwiftUI.Group {
-      pagers.colorScheme(.dark)
-      pagers.colorScheme(.light)
+      pagers.preferredColorScheme(.dark)
+      pagers.preferredColorScheme(.light)
     }
   }
   

--- a/Emitron/Emitron/UI/Library/Filtering/AppliedFilterTagButton.swift
+++ b/Emitron/Emitron/UI/Library/Filtering/AppliedFilterTagButton.swift
@@ -113,8 +113,8 @@ struct AppliedFilterTagButton: View {
 struct AppliedFilterView_Previews: PreviewProvider {
   static var previews: some View {
     SwiftUI.Group {
-      tags.colorScheme(.dark)
-      tags.colorScheme(.light)
+      tags.preferredColorScheme(.dark)
+      tags.preferredColorScheme(.light)
     }
   }
   

--- a/Emitron/Emitron/UI/Library/Filtering/FiltersHeaderView.swift
+++ b/Emitron/Emitron/UI/Library/Filtering/FiltersHeaderView.swift
@@ -101,8 +101,8 @@ struct FiltersHeaderView: View {
 struct FilterGroupView_Previews: PreviewProvider {
   static var previews: some View {
     SwiftUI.Group {
-      filters.colorScheme(.dark)
-      filters.colorScheme(.light)
+      filters.preferredColorScheme(.dark)
+      filters.preferredColorScheme(.light)
     }
   }
   

--- a/Emitron/Emitron/UI/Library/SearchFieldView.swift
+++ b/Emitron/Emitron/UI/Library/SearchFieldView.swift
@@ -94,8 +94,8 @@ struct SearchFieldView: View {
 
 struct SearchFieldView_Previews: PreviewProvider {
   static var previews: some View {
-    searchFields.colorScheme(.light)
-    searchFields.colorScheme(.dark)
+    searchFields.preferredColorScheme(.light)
+    searchFields.preferredColorScheme(.dark)
   }
   
   private static var searchFields: some View {

--- a/Emitron/Emitron/UI/My Tutorials/ToggleControlView.swift
+++ b/Emitron/Emitron/UI/My Tutorials/ToggleControlView.swift
@@ -75,8 +75,8 @@ struct ToggleControlView: View {
 struct ToggleControlView_Previews: PreviewProvider {
   static var previews: some View {
     SwiftUI.Group {
-      tabs.colorScheme(.light)
-      tabs.colorScheme(.dark)
+      tabs.preferredColorScheme(.light)
+      tabs.preferredColorScheme(.dark)
     }
   }
   

--- a/Emitron/Emitron/UI/Settings/Icons/IconChooserView.swift
+++ b/Emitron/Emitron/UI/Settings/Icons/IconChooserView.swift
@@ -47,8 +47,8 @@ struct IconChooserView: View {
 struct IconChooserView_Previews: PreviewProvider {
   static var previews: some View {
     SwiftUI.Group {
-      iconChooser.colorScheme(.dark)
-      iconChooser.colorScheme(.light)
+      iconChooser.preferredColorScheme(.dark)
+      iconChooser.preferredColorScheme(.light)
     }
   }
     

--- a/Emitron/Emitron/UI/Settings/Icons/IconView.swift
+++ b/Emitron/Emitron/UI/Settings/Icons/IconView.swift
@@ -58,8 +58,8 @@ struct IconView_Previews: PreviewProvider {
   
   static var previews: some View {
     SwiftUI.Group {
-      icons.colorScheme(.light)
-      icons.colorScheme(.dark)
+      icons.preferredColorScheme(.light)
+      icons.preferredColorScheme(.dark)
     }
   }
   

--- a/Emitron/Emitron/UI/Settings/Licenses/LicenseDetailView.swift
+++ b/Emitron/Emitron/UI/Settings/Licenses/LicenseDetailView.swift
@@ -57,8 +57,8 @@ struct LicenseDetailView_Previews: PreviewProvider {
   
   static var previews: some View {
     SwiftUI.Group {
-      LicenseDetailView(license: license).colorScheme(.light)
-      LicenseDetailView(license: license).colorScheme(.dark)
+      LicenseDetailView(license: license).preferredColorScheme(.light)
+      LicenseDetailView(license: license).preferredColorScheme(.dark)
     }
   }
 }

--- a/Emitron/Emitron/UI/Settings/Licenses/LicenseListView.swift
+++ b/Emitron/Emitron/UI/Settings/Licenses/LicenseListView.swift
@@ -70,8 +70,8 @@ struct LicenseListView_Previews: PreviewProvider {
   
   static var previews: some View {
     SwiftUI.Group {
-      LicenseListView(licenses: FossLicense.load(), visible: $visible).colorScheme(.light)
-      LicenseListView(licenses: FossLicense.load(), visible: $visible).colorScheme(.dark)
+      LicenseListView(licenses: FossLicense.load(), visible: $visible).preferredColorScheme(.light)
+      LicenseListView(licenses: FossLicense.load(), visible: $visible).preferredColorScheme(.dark)
     }
   }
 }

--- a/Emitron/Emitron/UI/Settings/SettingsDisclosureRow.swift
+++ b/Emitron/Emitron/UI/Settings/SettingsDisclosureRow.swift
@@ -60,8 +60,8 @@ struct SettingsDisclosureRow: View {
 struct SettingsDisclosureRow_Previews: PreviewProvider {
   static var previews: some View {
     SwiftUI.Group {
-      rows.colorScheme(.dark)
-      rows.colorScheme(.light)
+      rows.preferredColorScheme(.dark)
+      rows.preferredColorScheme(.light)
     }
   }
   

--- a/Emitron/Emitron/UI/Settings/SettingsList.swift
+++ b/Emitron/Emitron/UI/Settings/SettingsList.swift
@@ -44,8 +44,8 @@ extension SettingsList: View {
 
 struct SettingsList_Previews: PreviewProvider {
   static var previews: some View {
-    list.colorScheme(.dark)
-    list.colorScheme(.light)
+    list.preferredColorScheme(.dark)
+    list.preferredColorScheme(.light)
   }
 
   static var list: some View {

--- a/Emitron/Emitron/UI/Settings/SettingsSelectionView.swift
+++ b/Emitron/Emitron/UI/Settings/SettingsSelectionView.swift
@@ -76,8 +76,8 @@ struct SettingsSelectionView<Setting: SettingsSelectable>: View {
 struct SettingsSelectionView_Previews: PreviewProvider {
   static var previews: some View {
     SwiftUI.Group {
-      view.colorScheme(.dark)
-      view.colorScheme(.light)
+      view.preferredColorScheme(.dark)
+      view.preferredColorScheme(.light)
     }
   }
   

--- a/Emitron/Emitron/UI/Settings/SettingsToggleRow.swift
+++ b/Emitron/Emitron/UI/Settings/SettingsToggleRow.swift
@@ -52,8 +52,8 @@ struct SettingsToggleRow: View {
 struct SettingsToggleRow_Previews: PreviewProvider {
   static var previews: some View {
     SwiftUI.Group {
-      rows.colorScheme(.dark)
-      rows.colorScheme(.light)
+      rows.preferredColorScheme(.dark)
+      rows.preferredColorScheme(.light)
     }
   }
   

--- a/Emitron/Emitron/UI/Settings/SettingsView.swift
+++ b/Emitron/Emitron/UI/Settings/SettingsView.swift
@@ -96,8 +96,8 @@ struct SettingsView: View {
 struct SettingsView_Previews: PreviewProvider {
   static var previews: some View {
     SwiftUI.Group {
-      settingsView.colorScheme(.dark)
-      settingsView.colorScheme(.light)
+      settingsView.preferredColorScheme(.dark)
+      settingsView.preferredColorScheme(.light)
     }
   }
 

--- a/Emitron/Emitron/UI/Shared/Content Detail/Child Listing/ContinueButtonView.swift
+++ b/Emitron/Emitron/UI/Shared/Content Detail/Child Listing/ContinueButtonView.swift
@@ -37,8 +37,8 @@ struct ContinueButtonView: View {
 struct ContinueButtonView_Previews: PreviewProvider {
   static var previews: some View {
     VStack(spacing: 20) {
-      ContinueButtonView().colorScheme(.dark)
-      ContinueButtonView().colorScheme(.light)
+      ContinueButtonView().preferredColorScheme(.dark)
+      ContinueButtonView().preferredColorScheme(.light)
     }
     .padding(20)
     .background(Color.blue)

--- a/Emitron/Emitron/UI/Shared/Content Detail/Child Listing/LockedIconView.swift
+++ b/Emitron/Emitron/UI/Shared/Content Detail/Child Listing/LockedIconView.swift
@@ -42,8 +42,8 @@ struct LockedIconView: View {
 struct LockedIconView_Previews: PreviewProvider {
   static var previews: some View {
     HStack {
-      padlock.colorScheme(.dark)
-      padlock.colorScheme(.light)
+      padlock.preferredColorScheme(.dark)
+      padlock.preferredColorScheme(.light)
     }
   }
   

--- a/Emitron/Emitron/UI/Shared/Content Detail/Child Listing/PlayButtonView.swift
+++ b/Emitron/Emitron/UI/Shared/Content Detail/Child Listing/PlayButtonView.swift
@@ -37,8 +37,8 @@ struct PlayButtonView: View {
 struct PlayButtonView_Previews: PreviewProvider {
   static var previews: some View {
     HStack {
-      button.colorScheme(.dark)
-      button.colorScheme(.light)
+      button.preferredColorScheme(.dark)
+      button.preferredColorScheme(.light)
     }
   }
   

--- a/Emitron/Emitron/UI/Shared/Content Detail/Child Listing/VideoOverlayButtonView.swift
+++ b/Emitron/Emitron/UI/Shared/Content Detail/Child Listing/VideoOverlayButtonView.swift
@@ -77,8 +77,8 @@ struct VideoOverlayButtonView: View {
 struct VideoOverlayButtonView_Previews: PreviewProvider {
   static var previews: some View {
     SwiftUI.Group {
-      buttons.colorScheme(.dark)
-      buttons.colorScheme(.light)
+      buttons.preferredColorScheme(.dark)
+      buttons.preferredColorScheme(.light)
     }
   }
   

--- a/Emitron/Emitron/UI/Shared/Content Detail/CourseHeaderView.swift
+++ b/Emitron/Emitron/UI/Shared/Content Detail/CourseHeaderView.swift
@@ -53,8 +53,8 @@ struct CourseHeaderView: View {
 struct CourseHeaderView_Previews: PreviewProvider {
   static var previews: some View {
     SwiftUI.Group {
-      headers.colorScheme(.light)
-      headers.colorScheme(.dark)
+      headers.preferredColorScheme(.light)
+      headers.preferredColorScheme(.dark)
     }
   }
   

--- a/Emitron/Emitron/UI/Shared/Content List/CardView.swift
+++ b/Emitron/Emitron/UI/Shared/Content List/CardView.swift
@@ -168,9 +168,9 @@ struct MockDynamicContentDisplayable: DynamicContentDisplayable {
 struct CardView_Previews: PreviewProvider {
   static var previews: some View {
     SwiftUI.Group {
-      list.colorScheme(.dark)
+      list.preferredColorScheme(.dark)
       
-      list.colorScheme(.light)
+      list.preferredColorScheme(.light)
     }
   }
   

--- a/Emitron/Emitron/UI/Shared/Download Icon/ArrowInCircleView.swift
+++ b/Emitron/Emitron/UI/Shared/Download Icon/ArrowInCircleView.swift
@@ -43,8 +43,8 @@ struct ArrowInCircleView: View {
 struct ArrowInCircleView_Previews: PreviewProvider {
   static var previews: some View {
     SwiftUI.Group {
-      circles.colorScheme(.dark)
-      circles.colorScheme(.light)
+      circles.preferredColorScheme(.dark)
+      circles.preferredColorScheme(.light)
     }
   }
   

--- a/Emitron/Emitron/UI/Shared/Download Icon/CircleProgressBarView.swift
+++ b/Emitron/Emitron/UI/Shared/Download Icon/CircleProgressBarView.swift
@@ -62,8 +62,8 @@ struct CircularProgressBar: View {
 struct CircularProgressIndicator_Previews: PreviewProvider {
   static var previews: some View {
     SwiftUI.Group {
-      progressViews.colorScheme(.dark)
-      progressViews.colorScheme(.light)
+      progressViews.preferredColorScheme(.dark)
+      progressViews.preferredColorScheme(.light)
     }
   }
   

--- a/Emitron/Emitron/UI/Shared/Download Icon/DownloadIcon.swift
+++ b/Emitron/Emitron/UI/Shared/Download Icon/DownloadIcon.swift
@@ -45,8 +45,8 @@ extension DownloadIcon: View {
 
 struct DownloadIcon_Previews: PreviewProvider {
   static var previews: some View {
-    selectionList.colorScheme(.light)
-    selectionList.colorScheme(.dark)
+    selectionList.preferredColorScheme(.light)
+    selectionList.preferredColorScheme(.dark)
   }
   
   private static var selectionList: some View {

--- a/Emitron/Emitron/UI/Shared/Download Icon/DownloadWarningView.swift
+++ b/Emitron/Emitron/UI/Shared/Download Icon/DownloadWarningView.swift
@@ -42,8 +42,8 @@ struct DownloadWarningView: View {
 struct DownloadWarningView_Previews: PreviewProvider {
   static var previews: some View {
     HStack {
-      icon.colorScheme(.dark)
-      icon.colorScheme(.light)
+      icon.preferredColorScheme(.dark)
+      icon.preferredColorScheme(.light)
     }
   }
   

--- a/Emitron/Emitron/UI/Shared/Download Icon/SpinningCircleView.swift
+++ b/Emitron/Emitron/UI/Shared/Download Icon/SpinningCircleView.swift
@@ -98,8 +98,8 @@ struct SpinningCircleView: View {
 struct SpinningCircleView_Previews: PreviewProvider {
   static var previews: some View {
     SwiftUI.Group {
-      spinners.colorScheme(.dark)
-      spinners.colorScheme(.light)
+      spinners.preferredColorScheme(.dark)
+      spinners.preferredColorScheme(.light)
     }
   }
   

--- a/Emitron/Emitron/UI/Shared/MainButtonView.swift
+++ b/Emitron/Emitron/UI/Shared/MainButtonView.swift
@@ -119,8 +119,8 @@ struct MainButtonView: View {
 struct PrimaryButtonView_Previews: PreviewProvider {
   static var previews: some View {
     SwiftUI.Group {
-      buttons.colorScheme(.light)
-      buttons.colorScheme(.dark)
+      buttons.preferredColorScheme(.light)
+      buttons.preferredColorScheme(.dark)
     }
   }
   

--- a/Emitron/Emitron/UI/Shared/ProgressBarView.swift
+++ b/Emitron/Emitron/UI/Shared/ProgressBarView.swift
@@ -67,8 +67,8 @@ struct ProgressBarView: View {
 struct ProgressBarView_Previews: PreviewProvider {
   static var previews: some View {
     SwiftUI.Group {
-      bars.colorScheme(.light)
-      bars.colorScheme(.dark)
+      bars.preferredColorScheme(.light)
+      bars.preferredColorScheme(.dark)
     }
   }
   

--- a/Emitron/Emitron/UI/Shared/Tags/CompletedTag.swift
+++ b/Emitron/Emitron/UI/Shared/Tags/CompletedTag.swift
@@ -43,8 +43,8 @@ struct CompletedTag: View {
 struct CompletedTag_Previews: PreviewProvider {
   static var previews: some View {
     VStack(spacing: 10) {
-      completedTag.colorScheme(.light)
-      completedTag.colorScheme(.dark)
+      completedTag.preferredColorScheme(.light)
+      completedTag.preferredColorScheme(.dark)
     }
   }
   

--- a/Emitron/Emitron/UI/Shared/Tags/ProTag.swift
+++ b/Emitron/Emitron/UI/Shared/Tags/ProTag.swift
@@ -42,8 +42,8 @@ struct ProTag: View {
 struct ProTag_Previews: PreviewProvider {
   static var previews: some View {
     VStack(spacing: 10) {
-      proTag.colorScheme(.light)
-      proTag.colorScheme(.dark)
+      proTag.preferredColorScheme(.light)
+      proTag.preferredColorScheme(.dark)
     }
   }
   


### PR DESCRIPTION
[colorScheme(_:)](https://developer.apple.com/documentation/swiftui/view/colorscheme(_:)) is Deprecated recommendation is to use [preferredColorScheme(_:) ](https://developer.apple.com/documentation/swiftui/view/preferredcolorscheme(_:)) instead.

Signed-off-by: Franklin Byaruhanga <byaruhaf@appbantu.com>