### PR TITLE
Fixed UI elements overlapping issue in LoginView

### DIFF
--- a/Emitron/Emitron/UI/App Root/LoginView.swift
+++ b/Emitron/Emitron/UI/App Root/LoginView.swift
@@ -32,67 +32,73 @@ struct LoginView: View {
   @EnvironmentObject var sessionController: SessionController
   
   var body: some View {
-    VStack {
-      
-      Image("logo")
-        .padding([.top], 88)
-      
-      Spacer()
-      
-      PagerView(pageCount: 2, showIndicator: true) {
-        VStack {
-          Spacer()
-          Image("welcomeArtwork1")
-            .resizable()
-            .aspectRatio(contentMode: .fit)
-            .frame(width: 265)
-            .padding([.bottom], 40)
-          
-          Text("Watch anytime,\nanywhere")
-            .font(.uiTitle1)
-            .foregroundColor(.titleText)
-            .multilineTextAlignment(.center)
-            .padding([.bottom], 15)
-          
-          Text("Watch over 3,000+ video tutorials\non iPhone and iPad.")
-            .font(.uiLabel)
-            .foregroundColor(.contentText)
-            .multilineTextAlignment(.center)
-          Spacer()
-        }
-        .background(Color.backgroundColor)
+    GeometryReader { proxy in
+      VStack {
         
-        VStack {
-          Image("welcomeArtwork2")
-            .resizable()
-            .aspectRatio(contentMode: .fit)
-            .frame(width: 265)
-            .padding([.bottom], 40)
-          
-          Text("Take your videos on\nthe go")
-            .font(.uiTitle1)
-            .foregroundColor(.titleText)
-            .multilineTextAlignment(.center)
-            .padding([.bottom], 15)
-          
-          Text("Download and watch videos — even\nwhen you’re offline.")
-            .font(.uiLabel)
-            .foregroundColor(.contentText)
-            .multilineTextAlignment(.center)
-        }
+        Spacer()
+        
+        Image("logo")
+          .padding([.top], proxy.safeAreaInsets.top)
+        
+        Spacer()
+        
+        PagerView(pageCount: 2, showIndicator: true) {
+          VStack {
+            Spacer()
+            Image("welcomeArtwork1")
+              .resizable()
+              .aspectRatio(contentMode: .fit)
+              .frame(width: 265)
+              .padding([.bottom], proxy.size.height / 50)
+            
+            Text("Watch anytime,\nanywhere")
+              .font(.uiTitle1)
+              .foregroundColor(.titleText)
+              .multilineTextAlignment(.center)
+              .padding([.bottom], 15)
+            
+            Text("Watch over 3,000+ video tutorials\non iPhone and iPad.")
+              .font(.uiLabel)
+              .foregroundColor(.contentText)
+              .multilineTextAlignment(.center)
+            Spacer()
+          }
           .background(Color.backgroundColor)
+          
+          VStack {
+            Spacer()
+            Image("welcomeArtwork2")
+              .resizable()
+              .aspectRatio(contentMode: .fit)
+              .frame(width: 265)
+              .padding([.bottom], proxy.size.height / 50)
+            
+            Text("Take your videos on\nthe go")
+              .font(.uiTitle1)
+              .foregroundColor(.titleText)
+              .multilineTextAlignment(.center)
+              .padding([.bottom], 15)
+            
+            Text("Download and watch videos — even\nwhen you’re offline.")
+              .font(.uiLabel)
+              .foregroundColor(.contentText)
+              .multilineTextAlignment(.center)
+            Spacer()
+          }
+          .background(Color.backgroundColor)
+        }
+        
+        Spacer()
+        
+        MainButtonView(title: "Sign In", type: .primary(withArrow: true)) {
+          sessionController.login()
+        }
+        .padding([.leading, .trailing], 18)
+        .padding([.bottom], 38)
       }
-      
-      Spacer()
-      
-      MainButtonView(title: "Sign In", type: .primary(withArrow: true)) {
-        sessionController.login()
-      }
-      .padding([.leading, .trailing], 18)
-      .padding([.bottom], 38)
+      .background(Color.backgroundColor)
+      .edgesIgnoringSafeArea([.all])
     }
-    .background(Color.backgroundColor)
-    .edgesIgnoringSafeArea([.all])
   }
 }
 


### PR DESCRIPTION
Contents in PagerView would overlap with the page indicator for devices without borderless screen. The hard coded padding space for Image("logo") was too much for screens without large top safe area.
<img width="320" alt="Screen Shot 2021-08-25 at 7 57 13 PM" src="https://user-images.githubusercontent.com/80513126/130894423-a64d6f17-c010-4d8c-858f-1bf8c898937b.png">
I fixed it with GeometryReader by making the logo image padding adapt to top safe area and welcomeArtwork images padding adapt to the screen height. I also added two spacers to the second artwork page for consistency with the first page.
<img width="306" alt="Screen Shot 2021-08-25 at 7 58 05 PM" src="https://user-images.githubusercontent.com/80513126/130895018-a6361ee7-8d99-409b-b52b-2b0d3555ed06.png">


