### PR TITLE
Lazify MainView & TabNavView

### DIFF
--- a/Emitron/Emitron/UI/App Root/MainView.swift
+++ b/Emitron/Emitron/UI/App Root/MainView.swift
@@ -79,22 +79,22 @@ private extension MainView {
   @ViewBuilder var tabBarView: some View {
     switch sessionController.sessionState {
     case .online :
-      let libraryView = LibraryView(
-        filters: dataManager.filters,
-        libraryRepository: dataManager.libraryRepository
-      )
-      
-      let myTutorialsView = MyTutorialView(
-        state: .inProgress,
-        inProgressRepository: dataManager.inProgressRepository,
-        completedRepository: dataManager.completedRepository,
-        bookmarkRepository: dataManager.bookmarkRepository,
-        domainRepository: dataManager.domainRepository
-      )
-
       TabNavView(
-        libraryView: libraryView,
-        myTutorialsView: myTutorialsView,
+        libraryView: {
+          LibraryView(
+            filters: dataManager.filters,
+            libraryRepository: dataManager.libraryRepository
+          )
+        },
+        myTutorialsView: {
+          MyTutorialsView(
+            state: .inProgress,
+            inProgressRepository: dataManager.inProgressRepository,
+            completedRepository: dataManager.completedRepository,
+            bookmarkRepository: dataManager.bookmarkRepository,
+            domainRepository: dataManager.domainRepository
+          )
+        },
         downloadsView: downloadsView,
         settingsView: settingsView
       )

--- a/Emitron/Emitron/UI/App Root/MainView.swift
+++ b/Emitron/Emitron/UI/App Root/MainView.swift
@@ -50,12 +50,6 @@ struct MainView: View {
         }
     }
   }
-
-  private func makeReviewRequest() {
-    if let scene = UIApplication.shared.connectedScenes.first(where: { $0.activationState == .foregroundActive }) as? UIWindowScene {
-      SKStoreReviewController.requestReview(in: scene)
-    }
-  }
 }
 
 // MARK: - private
@@ -121,4 +115,10 @@ private extension MainView {
       LoadingView()
     }
   }
+
+  func makeReviewRequest() {
+   if let scene = UIApplication.shared.connectedScenes.first(where: { $0.activationState == .foregroundActive }) as? UIWindowScene {
+     SKStoreReviewController.requestReview(in: scene)
+   }
+ }
 }

--- a/Emitron/Emitron/UI/App Root/MainView.swift
+++ b/Emitron/Emitron/UI/App Root/MainView.swift
@@ -100,10 +100,12 @@ private extension MainView {
       )
       .environmentObject(tabViewModel)
     case .offline:
-      TabNavView(libraryView: OfflineView(),
-                 myTutorialsView: OfflineView(),
-                 downloadsView: downloadsView,
-                 settingsView: settingsView)
+      TabNavView(
+        libraryView: OfflineView.init,
+        myTutorialsView: OfflineView.init,
+        downloadsView: downloadsView,
+        settingsView: settingsView
+      )
         .environmentObject(tabViewModel)
     case .unknown:
       LoadingView()

--- a/Emitron/Emitron/UI/App Root/MainView.swift
+++ b/Emitron/Emitron/UI/App Root/MainView.swift
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Razeware LLC
+// Copyright (c) 2021 Razeware LLC
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -77,12 +77,6 @@ private extension MainView {
   }
   
   @ViewBuilder var tabBarView: some View {
-    let downloadsView = DownloadsView(
-      contentScreen: .downloads(permitted: sessionController.user?.canDownload ?? false),
-      downloadRepository: dataManager.downloadRepository
-    )
-    let settingsView = SettingsView(settingsManager: settingsManager)
-
     switch sessionController.sessionState {
     case .online :
       let libraryView = LibraryView(
@@ -114,6 +108,17 @@ private extension MainView {
     case .unknown:
       LoadingView()
     }
+  }
+
+  func downloadsView() -> DownloadsView {
+    .init(
+      contentScreen: .downloads(permitted: sessionController.user?.canDownload ?? false),
+      downloadRepository: dataManager.downloadRepository
+    )
+  }
+
+  func settingsView() -> SettingsView {
+    .init(settingsManager: settingsManager)
   }
 
   func makeReviewRequest() {

--- a/Emitron/Emitron/UI/App Root/TabNavView.swift
+++ b/Emitron/Emitron/UI/App Root/TabNavView.swift
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Razeware LLC
+// Copyright (c) 2021 Razeware LLC
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -33,14 +33,30 @@ struct TabNavView<
   MyTutorialsView: View,
   DownloadsView: View,
   SettingsView: View
->: View {
-  @EnvironmentObject var tabViewModel: TabViewModel
-  @EnvironmentObject var settingsManager: SettingsManager
-  let libraryView: LibraryView
-  let myTutorialsView: MyTutorialsView
-  let downloadsView: DownloadsView
-  let settingsView: SettingsView
+> {
+  init(
+    libraryView: @escaping () -> LibraryView,
+    myTutorialsView: @escaping () -> MyTutorialsView,
+    downloadsView: @escaping () -> DownloadsView,
+    settingsView: @escaping () -> SettingsView
+  ) {
+    self.libraryView = libraryView
+    self.myTutorialsView = myTutorialsView
+    self.downloadsView = downloadsView
+    self.settingsView = settingsView
+  }
 
+  @EnvironmentObject private var model: TabViewModel
+  @EnvironmentObject private var settingsManager: SettingsManager
+
+  private let libraryView: () -> LibraryView
+  private let myTutorialsView: () -> MyTutorialsView
+  private let downloadsView: () -> DownloadsView
+  private let settingsView: () -> SettingsView
+}
+
+// MARK: - View
+extension TabNavView: View {
   var body: some View {
     TabView(selection: $tabViewModel.selectedTab) {
       NavigationView {

--- a/Emitron/Emitron/UI/App Root/TabNavView.swift
+++ b/Emitron/Emitron/UI/App Root/TabNavView.swift
@@ -30,8 +30,8 @@ import SwiftUI
 
 struct TabNavView<
   LibraryView: View,
-  MyTutorialsView: View,
   DownloadsView: View,
+  MyTutorialsView: View,
   SettingsView: View
 > {
   init(

--- a/Emitron/Emitron/UI/App Root/TabNavView.swift
+++ b/Emitron/Emitron/UI/App Root/TabNavView.swift
@@ -58,49 +58,53 @@ struct TabNavView<
 // MARK: - View
 extension TabNavView: View {
   var body: some View {
-    TabView(selection: $tabViewModel.selectedTab) {
-      NavigationView {
-        libraryView
-      }
-        .tabItem {
-          Text(String.library)
-          Image("library")
-        }
-        .tag(MainTab.library)
-        .navigationViewStyle(StackNavigationViewStyle())
-        .accessibility(label: Text(String.library))
+    TabView(selection: $model.selectedTab) {
+      tab(
+        content: libraryView,
+        text: .library,
+        imageName: "library",
+        tag: .library
+      )
 
-      NavigationView {
-        downloadsView
-      }
-        .tabItem {
-          Text(String.downloads)
-          Image("downloadTabInactive")
-        }
-        .tag(MainTab.downloads)
-        .navigationViewStyle(StackNavigationViewStyle())
-        .accessibility(label: Text(String.downloads))
+      tab(
+        content: downloadsView,
+        text: .downloads,
+        imageName: "downloadTabInactive",
+        tag: .downloads
+      )
 
-      NavigationView { myTutorialsView }
-        .tabItem {
-          Text(String.myTutorials)
-          Image("myTutorials")
-        }
-        .tag(MainTab.myTutorials)
-        .navigationViewStyle(StackNavigationViewStyle())
-        .accessibility(label: .init(String.myTutorials))
-      
-      NavigationView { settingsView }
-        .tabItem {
-          Text(String.settings)
-          Image("settings")
-        }
-        .tag(MainTab.settings)
-        .navigationViewStyle(StackNavigationViewStyle())
-        .accessibility(label: .init(String.settings))
+      tab(
+        content: myTutorialsView,
+        text: .myTutorials,
+        imageName: "myTutorials",
+        tag: .myTutorials
+      )
+
+      tab(
+        content: settingsView,
+        text: .settings,
+        imageName: "settings",
+        tag: .settings
+      )
     }
     .accentColor(.accent)
   }
+}
+
+private func tab<Content: View>(
+  content: () -> Content,
+  text: String,
+  imageName: String,
+  tag: MainTab
+) -> some View {
+  NavigationView(content: content)
+    .tabItem {
+      Text(text)
+      Image(imageName)
+    }
+    .tag(tag)
+    .navigationViewStyle(StackNavigationViewStyle())
+    .accessibility(label: .init(text))
 }
 
 struct TabNavView_Previews: PreviewProvider {

--- a/Emitron/Emitron/UI/App Root/TabNavView.swift
+++ b/Emitron/Emitron/UI/App Root/TabNavView.swift
@@ -110,10 +110,10 @@ private func tab<Content: View>(
 struct TabNavView_Previews: PreviewProvider {
   static var previews: some View {
     TabNavView(
-      libraryView: Text("LIBRARY"),
-      myTutorialsView: Text("MY TUTORIALS"),
-      downloadsView: Text("DOWNLOADS"),
-      settingsView: Text("SETTINGS")
+      libraryView: { Text("LIBRARY") },
+      myTutorialsView: { Text("MY TUTORIALS") },
+      downloadsView: { Text("DOWNLOADS") },
+      settingsView: { Text("SETTINGS") }
     ).environmentObject(TabViewModel())
   }
 }

--- a/Emitron/Emitron/UI/My Tutorials/MyTutorialsView.swift
+++ b/Emitron/Emitron/UI/My Tutorials/MyTutorialsView.swift
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Razeware LLC
+// Copyright (c) 2021 Razeware LLC
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -70,8 +70,7 @@ extension MyTutorialsState: CaseIterable {
     Self.allCases.count
   }
 }
-
-struct MyTutorialView {
+struct MyTutorialsView {
   init(
     state: MyTutorialsState,
     inProgressRepository: InProgressRepository,
@@ -107,7 +106,7 @@ struct MyTutorialView {
 }
 
 // MARK: - View
-extension MyTutorialView: View {
+extension MyTutorialsView: View {
   var body: some View {
     contentView
       .navigationBarTitle(String.myTutorials)
@@ -115,7 +114,7 @@ extension MyTutorialView: View {
 }
 
 // MARK: - private
-private extension MyTutorialView {
+private extension MyTutorialsView {
   @ViewBuilder var contentView: some View {
     switch state {
     case .inProgress:


### PR DESCRIPTION
At the start of the app, views were getting created earlier than needed, and then put into closures again. I switched to storing view-creating closures and using them just-in-time.