### PR TITLE
Organize views

### DIFF
--- a/Emitron/Emitron/UI/Downloads/DownloadsView.swift
+++ b/Emitron/Emitron/UI/Downloads/DownloadsView.swift
@@ -29,10 +29,19 @@
 import SwiftUI
 
 struct DownloadsView: View {
-  @EnvironmentObject var downloadService: DownloadService
-  @State var contentScreen: ContentScreen
-  @ObservedObject var downloadRepository: DownloadRepository
+  init(
+    contentScreen: ContentScreen,
+    downloadRepository: DownloadRepository
+  ) {
+    self.contentScreen = contentScreen
+    self.downloadRepository = downloadRepository
+  }
 
+  private let contentScreen: ContentScreen
+  @ObservedObject private var downloadRepository: DownloadRepository
+
+  @EnvironmentObject private var downloadService: DownloadService
+  
   var body: some View {
     contentView
       .navigationBarTitle(String.downloads)

--- a/Emitron/Emitron/UI/Downloads/DownloadsView.swift
+++ b/Emitron/Emitron/UI/Downloads/DownloadsView.swift
@@ -43,13 +43,11 @@ struct DownloadsView: View {
   @EnvironmentObject private var downloadService: DownloadService
   
   var body: some View {
-    contentView
+    ContentListView(
+      contentRepository: downloadRepository,
+      downloadAction: downloadService,
+      contentScreen: contentScreen
+    )
       .navigationBarTitle(String.downloads)
-  }
-
-  private var contentView: some View {
-    ContentListView(contentRepository: downloadRepository,
-                    downloadAction: downloadService,
-                    contentScreen: contentScreen)
   }
 }

--- a/Emitron/Emitron/UI/Empty States/NoResultsView.swift
+++ b/Emitron/Emitron/UI/Empty States/NoResultsView.swift
@@ -78,8 +78,9 @@ extension NoResultsView: View {
         if contentScreen.showExploreButton {
           MainButtonView(
             title: "Explore Tutorials",
-            type: .primary(withArrow: true)) {
-              tabViewModel.selectedTab = .library
+            type: .primary(withArrow: true)
+          ) {
+            tabViewModel.selectedTab = .library
           }
           .padding([.horizontal, .bottom], 20)
         }

--- a/Emitron/Emitron/UI/Library/LibraryView.swift
+++ b/Emitron/Emitron/UI/Library/LibraryView.swift
@@ -61,11 +61,12 @@ struct LibraryView: View {
         filtersView
           .padding(.top, 10)
       }
+      
       numberAndSortView
         .padding(.vertical, 10)
     }
-      .padding(.horizontal, .sidePadding)
-      .background(Color.background)
+    .padding(.horizontal, .sidePadding)
+    .background(Color.background)
   }
 
   private var searchField: some View {
@@ -144,9 +145,9 @@ struct LibraryView: View {
           }
         }
       }
-        .padding([.horizontal], .sidePadding)
+      .padding([.horizontal], .sidePadding)
     }
-      .padding([.horizontal], -.sidePadding)
+    .padding([.horizontal], -.sidePadding)
   }
 
   private func updateFilters() {

--- a/Emitron/Emitron/UI/Settings/SettingsView.swift
+++ b/Emitron/Emitron/UI/Settings/SettingsView.swift
@@ -77,21 +77,22 @@ struct SettingsView: View {
         }
         .padding([.bottom], 25)
         
-          VStack {
-            if sessionController.user != nil {
-              Text("Logged in as \(sessionController.user?.username ?? "")")
-                .font(.uiCaption)
-                .foregroundColor(.contentText)
-            }
-            MainButtonView(title: "Sign Out", type: .destructive(withArrow: true)) {
-              DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-                sessionController.logout()
-                tabViewModel.selectedTab = .library
-              }
+        VStack {
+          if sessionController.user != nil {
+            Text("Logged in as \(sessionController.user?.username ?? "")")
+              .font(.uiCaption)
+              .foregroundColor(.contentText)
+          }
+          MainButtonView(title: "Sign Out", type: .destructive(withArrow: true)) {
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+              sessionController.logout()
+              tabViewModel.selectedTab = .library
             }
           }
-          .padding([.bottom, .horizontal], 18)
-      }.navigationBarTitle(String.settings)
+        }
+        .padding([.bottom, .horizontal], 18)
+      }
+      .navigationBarTitle(String.settings)
       .background(Color.background.edgesIgnoringSafeArea(.all))
   }
 }

--- a/Emitron/Emitron/UI/Settings/SettingsView.swift
+++ b/Emitron/Emitron/UI/Settings/SettingsView.swift
@@ -49,21 +49,21 @@ struct SettingsView: View {
         SettingsList(
           settingsManager: _settingsManager,
           canDownload: sessionController.user?.canDownload ?? false
-        ).padding([.horizontal], 20)
         
-        Section(header:
-          HStack {
+        ).padding(.horizontal, 20)
+        Section(
+          header: HStack {
             Text("App Icon")
               .font(.uiTitle4)
               .foregroundColor(.titleText)
             
             Spacer()
           }
-            .padding([.top], 20)
+            .padding(.top, 20)
         ) {
           IconChooserView()
         }
-        .padding([.horizontal], 20)
+        .padding(.horizontal, 20)
         
         Spacer()
 
@@ -73,7 +73,7 @@ struct SettingsView: View {
           Text("Software Licenses")
         }
         .sheet(isPresented: $licensesPresented) {
-            LicenseListView(visible: $licensesPresented)
+          LicenseListView(visible: $licensesPresented)
         }
         .padding([.bottom], 25)
         

--- a/Emitron/Emitron/UI/Settings/SettingsView.swift
+++ b/Emitron/Emitron/UI/Settings/SettingsView.swift
@@ -39,61 +39,61 @@ struct SettingsView: View {
   @EnvironmentObject var tabViewModel: TabViewModel
   @ObservedObject private var settingsManager: SettingsManager
   @State private var licensesPresented = false
-
+  
   init(settingsManager: SettingsManager) {
     self.settingsManager = settingsManager
   }
   
   var body: some View {
-      VStack {
-        SettingsList(
-          settingsManager: _settingsManager,
-          canDownload: sessionController.user?.canDownload ?? false
+    VStack {
+      SettingsList(
+        settingsManager: _settingsManager,
+        canDownload: sessionController.user?.canDownload ?? false
         
-        ).padding(.horizontal, 20)
-        Section(
-          header: HStack {
-            Text("App Icon")
-              .font(.uiTitle4)
-              .foregroundColor(.titleText)
-            
-            Spacer()
-          }
-            .padding(.top, 20)
-        ) {
-          IconChooserView()
+      ).padding(.horizontal, 20)
+      Section(
+        header: HStack {
+          Text("App Icon")
+            .font(.uiTitle4)
+            .foregroundColor(.titleText)
+          
+          Spacer()
         }
-        .padding(.horizontal, 20)
-        
-        Spacer()
-
-        Button {
-          licensesPresented.toggle()
-        } label: {
-          Text("Software Licenses")
-        }
-        .sheet(isPresented: $licensesPresented) {
-          LicenseListView(visible: $licensesPresented)
-        }
-        .padding([.bottom], 25)
-        
-        VStack {
-          if sessionController.user != nil {
-            Text("Logged in as \(sessionController.user?.username ?? "")")
-              .font(.uiCaption)
-              .foregroundColor(.contentText)
-          }
-          MainButtonView(title: "Sign Out", type: .destructive(withArrow: true)) {
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-              sessionController.logout()
-              tabViewModel.selectedTab = .library
-            }
-          }
-        }
-        .padding([.bottom, .horizontal], 18)
+          .padding(.top, 20)
+      ) {
+        IconChooserView()
       }
-      .navigationBarTitle(String.settings)
-      .background(Color.background.edgesIgnoringSafeArea(.all))
+      .padding(.horizontal, 20)
+      
+      Spacer()
+      
+      Button {
+        licensesPresented.toggle()
+      } label: {
+        Text("Software Licenses")
+      }
+      .sheet(isPresented: $licensesPresented) {
+        LicenseListView(visible: $licensesPresented)
+      }
+      .padding([.bottom], 25)
+      
+      VStack {
+        if sessionController.user != nil {
+          Text("Logged in as \(sessionController.user?.username ?? "")")
+            .font(.uiCaption)
+            .foregroundColor(.contentText)
+        }
+        MainButtonView(title: "Sign Out", type: .destructive(withArrow: true)) {
+          DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+            sessionController.logout()
+            tabViewModel.selectedTab = .library
+          }
+        }
+      }
+      .padding([.bottom, .horizontal], 18)
+    }
+    .navigationBarTitle(String.settings)
+    .background(Color.background.edgesIgnoringSafeArea(.all))
   }
 }
 

--- a/Emitron/Emitron/UI/Shared/CheckmarkView.swift
+++ b/Emitron/Emitron/UI/Shared/CheckmarkView.swift
@@ -29,18 +29,29 @@
 import SwiftUI
 
 // TODO: Refactor layout properties here
-struct CheckmarkView: View {
-  var isOn: Bool
-  
-  var outerSide: CGFloat = 24
-  var innerSide: CGFloat = 20
-  var outerRadius: CGFloat = 9
+struct CheckmarkView {
+  init(isOn: Bool, onChange: @escaping (Bool) -> Void) {
+    self.isOn = isOn
+    self.onChange = onChange
+  }
+
+  private let isOn: Bool
+  private let onChange: (Bool) -> Void
+
+  private let outerSide: CGFloat = 24
+  private let innerSide: CGFloat = 20
+  private let outerRadius: CGFloat = 9
+}
+
+// MARK: - private
+private extension CheckmarkView {
   var radiusRatio: CGFloat {
     outerRadius / outerSide
   }
-  
-  var onChange: (Bool) -> Void
-  
+}
+
+// MARK: - View
+extension CheckmarkView: View {
   var body: some View {
     Button {
       onChange(!isOn)

--- a/Emitron/Emitron/UI/Shared/CheckmarkView.swift
+++ b/Emitron/Emitron/UI/Shared/CheckmarkView.swift
@@ -59,7 +59,6 @@ extension CheckmarkView: View {
       if isOn {
         ZStack(alignment: .center) {
           Rectangle()
-
             .frame(maxWidth: outerSide, maxHeight: outerSide)
             .foregroundColor(.checkmarkBackground)
 
@@ -82,8 +81,8 @@ extension CheckmarkView: View {
 
 struct CheckmarkView_Previews: PreviewProvider {
   static var previews: some View {
-    CheckmarkView(isOn: true, onChange: { change in
+    CheckmarkView(isOn: true) { change in
       print("Changed to: \(change)")
-    })
+    }
   }
 }

--- a/Emitron/Emitron/UI/Shared/Content List/ContentListView.swift
+++ b/Emitron/Emitron/UI/Shared/Content List/ContentListView.swift
@@ -128,22 +128,18 @@ private extension ContentListView {
         loadMoreView
       }
     }
-      .if(!allowDelete) {
-        $0.gesture(
-          DragGesture().onChanged { _ in
-            UIApplication.dismissKeyboard()
-          }
-        )
-      }
-      .accessibility(identifier: "contentListView")
+    .if(!allowDelete) {
+      $0.gesture(
+        DragGesture().onChanged { _ in
+          UIApplication.dismissKeyboard()
+        }
+      )
+    }
+    .accessibility(identifier: "contentListView")
+    .listRowInsets(EdgeInsets())
+    .textCase(nil)
   }
 
-
-      .listRowInsets(EdgeInsets())
-      .textCase(nil)
-  }
-
-  
   var loadingView: some View {
     ZStack {
       Color.background.edgesIgnoringSafeArea(.all)

--- a/Emitron/Emitron/UI/Shared/Content List/ContentListView.swift
+++ b/Emitron/Emitron/UI/Shared/Content List/ContentListView.swift
@@ -103,6 +103,8 @@ private extension ContentListView {
             childContentsViewModel: contentRepository.childContentsViewModel(for: partialContent.id),
             dynamicContentViewModel: contentRepository.dynamicContentViewModel(for: partialContent.id)
           ),
+          // This EmptyView and the 0 opacity below are used for `label`
+          // instead of CardViewContainer, in order to hide navigation chevrons on the right.
           label: EmptyView.init
         )
           .opacity(0)

--- a/Emitron/Emitron/UI/Shared/Content List/ContentListView.swift
+++ b/Emitron/Emitron/UI/Shared/Content List/ContentListView.swift
@@ -89,11 +89,6 @@ private extension ContentListView {
     }
   }
 
-  @ViewBuilder var listContentView: some View {
-    cardsView
-    loadMoreView
-  }
-
   var cardsView: some View {
     ForEach(contentRepository.contents, id: \.id) { partialContent in
       ZStack {
@@ -128,8 +123,9 @@ private extension ContentListView {
   
   var listView: some View {
     List {
-      makeSectionList {
-        listContentView
+      Section(header: header) {
+        cardsView
+        loadMoreView
       }
     }
       .if(!allowDelete) {
@@ -143,10 +139,6 @@ private extension ContentListView {
   }
 
 
-  func makeSectionList<Content: View>(
-    @ViewBuilder content: () -> Content
-  ) -> some View {
-    Section(header: header, content: content)
       .listRowInsets(EdgeInsets())
       .textCase(nil)
   }

--- a/Emitron/Emitron/UI/Shared/Content List/ContentListView.swift
+++ b/Emitron/Emitron/UI/Shared/Content List/ContentListView.swift
@@ -142,12 +142,6 @@ private extension ContentListView {
       .accessibility(identifier: "contentListView")
   }
 
-  func makeList<Content: View>(
-    @ViewBuilder content: () -> Content
-  ) -> some View {
-    Section(header: header, content: content)
-      .listRowInsets(EdgeInsets())
-  }
 
   func makeSectionList<Content: View>(
     @ViewBuilder content: () -> Content
@@ -157,11 +151,6 @@ private extension ContentListView {
       .textCase(nil)
   }
 
-  func makeList<Content: View>(
-    @ViewBuilder content: () -> Content
-  ) -> some View where Header.Body == Never {
-    content()
-  }
   
   var loadingView: some View {
     ZStack {

--- a/Emitron/Emitron/UI/Shared/Content List/ContentListView.swift
+++ b/Emitron/Emitron/UI/Shared/Content List/ContentListView.swift
@@ -195,16 +195,19 @@ private extension ContentListView {
       downloadAction
         .deleteDownload(contentId: content.id)
         .receive(on: RunLoop.main)
-        .sink(receiveCompletion: { completion in
-          if case .failure(let error) = completion {
-            Failure
-              .downloadAction(from: String(describing: type(of: self)), reason: "Unable to perform download action: \(error)")
-              .log()
-            self.messageBus.post(message: Message(level: .error, message: error.localizedDescription))
+        .sink(
+          receiveCompletion: { completion in
+            if case .failure(let error) = completion {
+              Failure
+                .downloadAction(from: String(describing: type(of: self)), reason: "Unable to perform download action: \(error)")
+                .log()
+              self.messageBus.post(message: Message(level: .error, message: error.localizedDescription))
+            }
+          },
+          receiveValue: {  _ in
+            self.messageBus.post(message: Message(level: .success, message: .downloadDeleted))
           }
-        }) {  _ in
-          self.messageBus.post(message: Message(level: .success, message: .downloadDeleted))
-        }
+        )
         .store(in: &deleteSubscriptions)
     }
   }


### PR DESCRIPTION
As with the previous pull request, I cleaned up and organized several views while preparing to fix (though not currently fixing) https://github.com/razeware/emitron-iOS/issues/598. These views didn't have as many changes as `ContentListView`.