### PR TITLE
Fix SwiftLint warning Vertical Whitespace before Closing Braces

### DIFF
--- a/Emitron/Emitron/UI/Settings/SettingsView.swift
+++ b/Emitron/Emitron/UI/Settings/SettingsView.swift
@@ -48,8 +48,7 @@ struct SettingsView: View {
     VStack {
       SettingsList(
         settingsManager: _settingsManager,
-        canDownload: sessionController.user?.canDownload ?? false
-        
+        canDownload: sessionController.user?.canDownload ?? false        
       ).padding(.horizontal, 20)
       Section(
         header: HStack {


### PR DESCRIPTION
Fix SwiftLint warning

Vertical Whitespace before Closing Braces Violation: Don't include vertical whitespace (empty line) before closing braces. (vertical_whitespace_closing_braces)

<!-- 🚀 Thank you for contributing! -->

<!-- Describe your changes clearly and use examples if possible. -->

<!-- If this PR fixes an issue, then please link to that issue. If the PR
  is large (or likely to be), it would be prudent to open a discussion in
  advance of the PR to avoid doing large amounts of work that might not
  get merged. -->

<!-- When this PR is merged, a new version of emitron will be pushed to Testflight automatically -->
