### PR TITLE
Moves Bookmarks to the middle and Completed to the trailing position

### DIFF
--- a/Emitron/Emitron/UI/My Tutorials/MyTutorialsView.swift
+++ b/Emitron/Emitron/UI/My Tutorials/MyTutorialsView.swift
@@ -37,10 +37,10 @@ enum MyTutorialsState: String {
     switch self {
     case .inProgress:
       return "In Progress"
-    case .completed:
-      return "Completed"
     case .bookmarked:
       return "Bookmarks"
+    case .completed:
+      return "Completed"
     }
   }
 }
@@ -113,15 +113,15 @@ private extension MyTutorialsView {
         contentRepository: inProgressRepository,
         contentScreen: .inProgress
       )
-    case .completed:
-      makeContentListView(
-        contentRepository: completedRepository,
-        contentScreen: .completed
-      )
     case .bookmarked:
       makeContentListView(
         contentRepository: bookmarkRepository,
         contentScreen: .bookmarked
+      )
+    case .completed:
+      makeContentListView(
+        contentRepository: completedRepository,
+        contentScreen: .completed
       )
     }
   }
@@ -143,15 +143,15 @@ private extension MyTutorialsView {
                 inProgressRepository.reload()
                 reloadProgression = false
               }
-            case .completed:
-              if reloadCompleted {
-                completedRepository.reload()
-                reloadCompleted = false
-              }
             case .bookmarked:
               if reloadBookmarks {
                 bookmarkRepository.reload()
                 reloadBookmarks = false
+              }
+            case .completed:
+              if reloadCompleted {
+                completedRepository.reload()
+                reloadCompleted = false
               }
             }
           })

--- a/Emitron/Emitron/UI/My Tutorials/MyTutorialsView.swift
+++ b/Emitron/Emitron/UI/My Tutorials/MyTutorialsView.swift
@@ -30,8 +30,8 @@ import SwiftUI
 
 enum MyTutorialsState: String {
   case inProgress
-  case completed
   case bookmarked
+  case completed
   
   var displayString: String {
     switch self {

--- a/Emitron/Emitron/UI/My Tutorials/MyTutorialsView.swift
+++ b/Emitron/Emitron/UI/My Tutorials/MyTutorialsView.swift
@@ -61,6 +61,11 @@ extension MyTutorialsState: CaseIterable {
   }
 }
 
+// MARK: - Identifiable
+extension MyTutorialsState: Identifiable {
+  var id: Self { self }
+}
+
 // MARK: -
 struct MyTutorialsView {
   init(

--- a/Emitron/Emitron/UI/My Tutorials/ToggleControlView.swift
+++ b/Emitron/Emitron/UI/My Tutorials/ToggleControlView.swift
@@ -75,9 +75,9 @@ struct ToggleControlView: View {
 struct ToggleControlView_Previews: PreviewProvider {
   static var previews: some View {
     VStack(spacing: 40) {
-      ToggleControlView(toggleState: .inProgress)
-      ToggleControlView(toggleState: .completed)
-      ToggleControlView(toggleState: .bookmarked)
+      ForEach(MyTutorialsState.allCases, id: \.self) {
+        ToggleControlView(toggleState: $0)
+      }
     }
     .padding([.vertical], 40)
     .padding([.horizontal], 10)

--- a/Emitron/Emitron/UI/My Tutorials/ToggleControlView.swift
+++ b/Emitron/Emitron/UI/My Tutorials/ToggleControlView.swift
@@ -41,9 +41,9 @@ struct ToggleControlView: View {
         .frame(height: 2)
       
       HStack {
-        toggleButton(for: .inProgress)
-        toggleButton(for: .completed)
-        toggleButton(for: .bookmarked)
+        ForEach(MyTutorialsState.allCases, id: \.self) { state in
+          toggleButton(for: state)
+        }
       }
     }
   }

--- a/Emitron/Emitron/UI/My Tutorials/ToggleControlView.swift
+++ b/Emitron/Emitron/UI/My Tutorials/ToggleControlView.swift
@@ -41,9 +41,7 @@ struct ToggleControlView: View {
         .frame(height: 2)
       
       HStack {
-        ForEach(MyTutorialsState.allCases, id: \.self) { state in
-          toggleButton(for: state)
-        }
+        ForEach(MyTutorialsState.allCases, id: \.self, content: toggleButton)
       }
     }
   }

--- a/Emitron/Emitron/UI/My Tutorials/ToggleControlView.swift
+++ b/Emitron/Emitron/UI/My Tutorials/ToggleControlView.swift
@@ -28,12 +28,23 @@
 
 import SwiftUI
 
-struct ToggleControlView: View {
-  @State var toggleState: MyTutorialsState
-  @EnvironmentObject var messageBus: MessageBus
+struct ToggleControlView {
+  @State private var toggleState: MyTutorialsState
+  @EnvironmentObject private var messageBus: MessageBus
 
-  var toggleUpdated: ((MyTutorialsState) -> Void)?
-  
+  private let toggleUpdated: ((MyTutorialsState) -> Void)?
+
+  init(
+    toggleState: MyTutorialsState,
+    toggleUpdated: ((MyTutorialsState) -> Void)? = nil
+  ) {
+    self.toggleState = toggleState
+    self.toggleUpdated = toggleUpdated
+  }
+}
+
+// MARK: - View
+extension ToggleControlView: View {
   var body: some View {
     ZStack(alignment: .bottom) {
       RoundedRectangle(cornerRadius: 1)
@@ -45,7 +56,24 @@ struct ToggleControlView: View {
       }
     }
   }
-  
+}
+
+struct ToggleControlView_Previews: PreviewProvider {
+  static var previews: some View {
+    VStack(spacing: 40) {
+      ForEach(MyTutorialsState.allCases, id: \.self) {
+        ToggleControlView(toggleState: $0)
+      }
+    }
+    .padding([.vertical], 40)
+    .padding([.horizontal], 10)
+    .background(Color.background)
+    .inAllColorSchemes
+  }
+}
+
+// MARK: - private
+private extension ToggleControlView {
   private func toggleButton(for state: MyTutorialsState) -> some View {
     Button {
       guard state != toggleState else { return }
@@ -67,19 +95,5 @@ struct ToggleControlView: View {
         .fill(toggleState == state ? Color.toggleLineSelected : .toggleLineDeselected)
         .frame(height: 2)
     }
-  }
-}
-
-struct ToggleControlView_Previews: PreviewProvider {
-  static var previews: some View {
-    VStack(spacing: 40) {
-      ForEach(MyTutorialsState.allCases, id: \.self) {
-        ToggleControlView(toggleState: $0)
-      }
-    }
-    .padding([.vertical], 40)
-    .padding([.horizontal], 10)
-    .background(Color.background)
-    .inAllColorSchemes
   }
 }

--- a/Emitron/Emitron/UI/My Tutorials/ToggleControlView.swift
+++ b/Emitron/Emitron/UI/My Tutorials/ToggleControlView.swift
@@ -41,7 +41,7 @@ struct ToggleControlView: View {
         .frame(height: 2)
       
       HStack {
-        ForEach(MyTutorialsState.allCases, id: \.self, content: toggleButton)
+        ForEach(MyTutorialsState.allCases, content: toggleButton)
       }
     }
   }


### PR DESCRIPTION
This pull request moves the My Tutorials Bookmarks tab to the middle and the Completed tab to the end. This is done by swapping the case positions in `MyTutorialsState`. In `ToggleControlView` the ` toggleButton(for:)`'s are wrapped in a `ForEach` to maintain the swipe integrity. 