### PR TITLE
Remove bookmark banner

### DIFF
--- a/Emitron/Emitron/Data/ViewModels/DynamicContentViewModel.swift
+++ b/Emitron/Emitron/Data/ViewModels/DynamicContentViewModel.swift
@@ -186,6 +186,8 @@ final class DynamicContentViewModel: ObservableObject, DynamicContentDisplayable
     } else {
       do {
         try syncAction.createBookmark(for: contentId)
+        let generator = UINotificationFeedbackGenerator()
+        generator.notificationOccurred(.success)
       } catch {
         messageBus.post(message: Message(level: .error, message: .bookmarkCreatedError))
         Failure

--- a/Emitron/Emitron/Data/ViewModels/DynamicContentViewModel.swift
+++ b/Emitron/Emitron/Data/ViewModels/DynamicContentViewModel.swift
@@ -177,7 +177,6 @@ final class DynamicContentViewModel: ObservableObject, DynamicContentDisplayable
     if bookmarked {
       do {
         try syncAction.deleteBookmark(for: contentId)
-        messageBus.post(message: Message(level: .success, message: .bookmarkDeleted))
       } catch {
         messageBus.post(message: Message(level: .error, message: .bookmarkDeletedError))
         Failure
@@ -187,7 +186,6 @@ final class DynamicContentViewModel: ObservableObject, DynamicContentDisplayable
     } else {
       do {
         try syncAction.createBookmark(for: contentId)
-        messageBus.post(message: Message(level: .success, message: .bookmarkCreated))
       } catch {
         messageBus.post(message: Message(level: .error, message: .bookmarkCreatedError))
         Failure

--- a/Emitron/Emitron/Data/ViewModels/DynamicContentViewModel.swift
+++ b/Emitron/Emitron/Data/ViewModels/DynamicContentViewModel.swift
@@ -72,27 +72,6 @@ final class DynamicContentViewModel: ObservableObject, DynamicContentDisplayable
     configureSubscriptions()
   }
   
-  private func configureSubscriptions() {
-    repository
-      .contentDynamicState(for: contentId)
-      .removeDuplicates()
-      .sink(receiveCompletion: { [weak self] completion in
-        self?.state = .failed
-        Failure
-          .repositoryLoad(from: "DynamicContentViewModel", reason: "Unable to retrieve dynamic download content: \(completion)")
-          .log()
-      }) { [weak self] contentState in
-        guard let self = self else { return }
-
-        self.viewProgress = ContentViewProgressDisplayable(progression: contentState.progression)
-        self.downloadProgress = DownloadProgressDisplayable(download: contentState.download)
-        self.bookmarked = contentState.bookmark != nil
-        self.dynamicContentState = contentState
-        self.state = .hasData
-      }
-      .store(in: &subscriptions)
-  }
-  
   func downloadTapped() -> DownloadDeletionConfirmation? {
     guard state == .hasData else { return nil }
     
@@ -171,8 +150,10 @@ final class DynamicContentViewModel: ObservableObject, DynamicContentDisplayable
   }
   
   func bookmarkTapped() {
-    guard state == .hasData,
-      let syncAction = syncAction else { return }
+    guard
+      state == .hasData,
+      let syncAction = syncAction
+    else { return }
     
     if bookmarked {
       do {
@@ -186,8 +167,7 @@ final class DynamicContentViewModel: ObservableObject, DynamicContentDisplayable
     } else {
       do {
         try syncAction.createBookmark(for: contentId)
-        let generator = UINotificationFeedbackGenerator()
-        generator.notificationOccurred(.success)
+        UINotificationFeedbackGenerator().notificationOccurred(.success)
       } catch {
         messageBus.post(message: Message(level: .error, message: .bookmarkCreatedError))
         Failure
@@ -238,5 +218,29 @@ final class DynamicContentViewModel: ObservableObject, DynamicContentDisplayable
       settingsManager: settingsManager,
       dismissClosure: dismissClosure
     )
+  }
+}
+
+// MARK: - private
+private extension DynamicContentViewModel {
+  func configureSubscriptions() {
+    repository
+      .contentDynamicState(for: contentId)
+      .removeDuplicates()
+      .sink(receiveCompletion: { [weak self] completion in
+        self?.state = .failed
+        Failure
+          .repositoryLoad(from: "DynamicContentViewModel", reason: "Unable to retrieve dynamic download content: \(completion)")
+          .log()
+      }) { [weak self] contentState in
+        guard let self = self else { return }
+        
+        self.viewProgress = ContentViewProgressDisplayable(progression: contentState.progression)
+        self.downloadProgress = DownloadProgressDisplayable(download: contentState.download)
+        self.bookmarked = contentState.bookmark != nil
+        self.dynamicContentState = contentState
+        self.state = .hasData
+      }
+      .store(in: &subscriptions)
   }
 }


### PR DESCRIPTION
This pull request removes the banner message on changes of a bookmark status. [#623](https://github.com/razeware/emitron-iOS/issues/623)

Haptic feedback was added when a bookmark is successfully created. Similar behavior occurs in the Spotify app when liking a song.