### PR TITLE
Update keychain-swift Package

### DIFF
--- a/Emitron/Emitron.xcodeproj/project.pbxproj
+++ b/Emitron/Emitron.xcodeproj/project.pbxproj
@@ -2679,7 +2679,7 @@
 			repositoryURL = "https://github.com/evgenyneu/keychain-swift";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 19.0.0;
+				minimumVersion = 20.0.0;
 			};
 		};
 		22C0512323A4C99E004D1223 /* XCRemoteSwiftPackageReference "Kingfisher" */ = {

--- a/Emitron/Emitron.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Emitron/Emitron.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/evgenyneu/keychain-swift",
         "state": {
           "branch": null,
-          "revision": "96fb84f45a96630e7583903bd7e08cf095c7a7ef",
-          "version": "19.0.0"
+          "revision": "d108a1fa6189e661f91560548ef48651ed8d93b9",
+          "version": "20.0.0"
         }
       },
       {

--- a/Emitron/emitronTests/Persistence/PersistenceStore+DownloadsTest.swift
+++ b/Emitron/emitronTests/Persistence/PersistenceStore+DownloadsTest.swift
@@ -113,7 +113,7 @@ class PersistenceStore_DownloadsTest: XCTestCase {
       collectionExpectation.fulfill()
     }
     
-    wait(for: [collectionExpectation], timeout: 10)
+    wait(for: [collectionExpectation], timeout: 15)
   }
   
   func testTransitionEpisodeToDownloadedUpdatesCollection() throws {


### PR DESCRIPTION
Update keychain-swift to clear warning "Conversion to Swift 5 is available" caused by swift-tools-version

<!-- 🚀 Thank you for contributing! -->

<!-- Describe your changes clearly and use examples if possible. -->

<!-- If this PR fixes an issue, then please link to that issue. If the PR
  is large (or likely to be), it would be prudent to open a discussion in
  advance of the PR to avoid doing large amounts of work that might not
  get merged. -->

<!-- When this PR is merged, a new version of emitron will be pushed to Testflight automatically -->
