### PR TITLE
Fix minor swiftlint warnings

### DIFF
--- a/Emitron/Emitron.xcodeproj/project.pbxproj
+++ b/Emitron/Emitron.xcodeproj/project.pbxproj
@@ -1932,7 +1932,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint --no-cache\nelse\n    echo \"SwiftLint does not exist, download from https://github.com/realm/SwiftLint\"\nfi\n";
+			shellScript = "export PATH=\"$PATH:/opt/homebrew/bin\"\n\nif which swiftlint >/dev/null; then\n    swiftlint --no-cache\nelse\n    echo \"SwiftLint does not exist, download from https://github.com/realm/SwiftLint\"\nfi\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/Emitron/Emitron/Extensions/Binding+Extensions.swift
+++ b/Emitron/Emitron/Extensions/Binding+Extensions.swift
@@ -29,7 +29,8 @@
 import struct SwiftUI.Binding
 
 public extension Binding where Value == Bool {
-  prefix static func ! (binding: Self) -> Self {
+  // swiftlint:disable:next operator_whitespace
+  prefix static func !(binding: Self) -> Self {
     .init(
       get: { !binding.wrappedValue },
       set: { binding.wrappedValue = !$0 }

--- a/Emitron/Emitron/Extensions/Binding+Extensions.swift
+++ b/Emitron/Emitron/Extensions/Binding+Extensions.swift
@@ -29,11 +29,10 @@
 import struct SwiftUI.Binding
 
 public extension Binding where Value == Bool {
-  prefix static func !(binding: Self) -> Self {
+  prefix static func ! (binding: Self) -> Self {
     .init(
       get: { !binding.wrappedValue },
       set: { binding.wrappedValue = !$0 }
     )
   }
 }
-

--- a/Emitron/Emitron/Persistence/PersistenceStore+Keychain.swift
+++ b/Emitron/Emitron/Persistence/PersistenceStore+Keychain.swift
@@ -42,8 +42,8 @@ extension PersistenceStore {
     }
     
     return KeychainSwift().set(encoded,
-                        forKey: ssoUserKey,
-                        withAccess: .accessibleAfterFirstUnlock)
+                               forKey: ssoUserKey,
+                               withAccess: .accessibleAfterFirstUnlock)
   }
   
   func userFromKeychain(_ decoder: JSONDecoder = .init()) -> User? {


### PR DESCRIPTION
This PR Fixes, the following swiftlint warnings

- Operator Function Whitespace Violation: Operators should be surrounded by a single whitespace when defining them. (operator_whitespace)
- Trailing Newline Violation: Files should have a single trailing newline. (trailing_newline)
- Vertical Parameter Alignment On Call Violation: Function parameters should be aligned vertically if they're in multiple lines in a method call. (vertical_parameter_alignment_on_call)

Signed-off-by: Franklin Byaruhanga <byaruhaf@appbantu.com>

<!-- 🚀 Thank you for contributing! -->

<!-- Describe your changes clearly and use examples if possible. -->

<!-- If this PR fixes an issue, then please link to that issue. If the PR
  is large (or likely to be), it would be prudent to open a discussion in
  advance of the PR to avoid doing large amounts of work that might not
  get merged. -->

<!-- When this PR is merged, a new version of emitron will be pushed to Testflight automatically -->
