### PR TITLE
Remove Deprecated navigationBarTitle

### DIFF
--- a/Emitron/Emitron/UI/Downloads/DownloadsView.swift
+++ b/Emitron/Emitron/UI/Downloads/DownloadsView.swift
@@ -48,6 +48,6 @@ struct DownloadsView: View {
       downloadAction: downloadService,
       contentScreen: contentScreen
     )
-      .navigationBarTitle(String.downloads)
+      .navigationTitle(String.downloads)
   }
 }

--- a/Emitron/Emitron/UI/Library/LibraryView.swift
+++ b/Emitron/Emitron/UI/Library/LibraryView.swift
@@ -43,7 +43,7 @@ struct LibraryView: View {
 
   var body: some View {
     contentView
-      .navigationBarTitle(
+      .navigationTitle(
         Text(String.library)
       )
       .sheet(isPresented: $filtersPresented) {

--- a/Emitron/Emitron/UI/My Tutorials/MyTutorialsView.swift
+++ b/Emitron/Emitron/UI/My Tutorials/MyTutorialsView.swift
@@ -105,7 +105,7 @@ struct MyTutorialsView {
 extension MyTutorialsView: View {
   var body: some View {
     contentView
-      .navigationBarTitle(String.myTutorials)
+      .navigationTitle(String.myTutorials)
   }
 }
 

--- a/Emitron/Emitron/UI/Settings/Licenses/LicenseListView.swift
+++ b/Emitron/Emitron/UI/Settings/Licenses/LicenseListView.swift
@@ -45,7 +45,7 @@ struct LicenseListView: View {
               .font(.uiLabel)
               .foregroundColor(.contentText)
           }
-            .navigationBarTitle("Software Licenses")
+            .navigationTitle("Software Licenses")
             .navigationBarItems(trailing: dismissButton)
         }
       }

--- a/Emitron/Emitron/UI/Settings/SettingsSelectionView.swift
+++ b/Emitron/Emitron/UI/Settings/SettingsSelectionView.swift
@@ -61,13 +61,13 @@ struct SettingsSelectionView<Setting: SettingsSelectable>: View {
       
       Spacer()
     }
-      .navigationTitle(
-        Text(title)
-          .font(.uiTitle5)
-          .foregroundColor(.titleText)
-      )
-      .navigationBarTitleDisplayMode(.inline)
-        .padding(20)
+    .navigationTitle(
+      Text(title)
+        .font(.uiTitle5)
+        .foregroundColor(.titleText)
+    )
+    .navigationBarTitleDisplayMode(.inline)
+    .padding(20)
     .background(Color.background.edgesIgnoringSafeArea(.all))
   }
 }

--- a/Emitron/Emitron/UI/Settings/SettingsSelectionView.swift
+++ b/Emitron/Emitron/UI/Settings/SettingsSelectionView.swift
@@ -61,12 +61,12 @@ struct SettingsSelectionView<Setting: SettingsSelectable>: View {
       
       Spacer()
     }
-      .navigationBarTitle(
+      .navigationTitle(
         Text(title)
           .font(.uiTitle5)
-          .foregroundColor(.titleText),
-        displayMode: .inline
+          .foregroundColor(.titleText)
       )
+      .navigationBarTitleDisplayMode(.inline)
         .padding(20)
     .background(Color.background.edgesIgnoringSafeArea(.all))
   }

--- a/Emitron/Emitron/UI/Settings/SettingsView.swift
+++ b/Emitron/Emitron/UI/Settings/SettingsView.swift
@@ -119,7 +119,7 @@ struct SettingsView: View {
       }
       .padding([.bottom, .horizontal], 18)
     }
-    .navigationBarTitle(String.settings)
+    .navigationTitle(String.settings)
     .background(Color.background.edgesIgnoringSafeArea(.all))
   }
 }

--- a/Emitron/Emitron/UI/Shared/Content Detail/ContentDetailView.swift
+++ b/Emitron/Emitron/UI/Shared/Content Detail/ContentDetailView.swift
@@ -88,7 +88,8 @@ private extension ContentDetailView {
         }
       }
     }
-    .navigationBarTitle(Text(""), displayMode: .inline)
+    .navigationTitle(Text(""))
+    .navigationBarTitleDisplayMode(.inline)
     .background(Color.background)
     .onReceive(videoCompletedNotification) { _ in
       checkReviewRequest = true


### PR DESCRIPTION
Remove Deprecated [navigationBarTitle(_:) ](https://developer.apple.com/documentation/swiftui/view/navigationbartitle(_:)-6p1k7) replace it with[ navigationTitle(_:)](https://developer.apple.com/documentation/swiftui/view/navigationtitle(_:)-5di1u)

Signed-off-by: Franklin Byaruhanga <byaruhaf@appbantu.com>

<!-- 🚀 Thank you for contributing! -->

<!-- Describe your changes clearly and use examples if possible. -->

<!-- If this PR fixes an issue, then please link to that issue. If the PR
  is large (or likely to be), it would be prudent to open a discussion in
  advance of the PR to avoid doing large amounts of work that might not
  get merged. -->

<!-- When this PR is merged, a new version of emitron will be pushed to Testflight automatically -->
