### PR TITLE
Fix Warning: Non-constant range: argument must be an integer literal

### DIFF
--- a/Emitron/Emitron/UI/Generic/PagingIndicatorView.swift
+++ b/Emitron/Emitron/UI/Generic/PagingIndicatorView.swift
@@ -34,7 +34,7 @@ struct PagingIndicatorView: View {
   
   var body: some View {
     HStack(spacing: 9) {
-      ForEach(0..<pageCount - 1) { index in
+      ForEach(0..<pageCount - 1, id: \.self) { index in
         Circle()
           .fill(index == currentIndex ? Color.accent : .borderColor)
           .frame(width: 9, height: 9)

--- a/Emitron/emitronTests/Downloads/DownloadServiceTest.swift
+++ b/Emitron/emitronTests/Downloads/DownloadServiceTest.swift
@@ -409,7 +409,7 @@ class DownloadServiceTest: XCTestCase {
     }
     .record()
     
-    let completion = try wait(for: recorder.completion, timeout: 10)
+    let completion = try wait(for: recorder.completion, timeout: 20)
     XCTAssert(completion == .finished)
 
     // Adds downloads to the collection and the individual episodes


### PR DESCRIPTION
This fixes a new warning introduced with Xcode 13.3 beta 2 (13E5095k)
which was announced in [WWDC21: Demystify SwiftUI](https://developer.apple.com/videos/play/wwdc2021/10022/)

<!-- 🚀 Thank you for contributing! -->

<!-- Describe your changes clearly and use examples if possible. -->

<!-- If this PR fixes an issue, then please link to that issue. If the PR
  is large (or likely to be), it would be prudent to open a discussion in
  advance of the PR to avoid doing large amounts of work that might not
  get merged. -->

<!-- When this PR is merged, a new version of emitron will be pushed to Testflight automatically -->
