### PR TITLE
Revert to using a ZStack for video player

### DIFF
--- a/Emitron/Emitron/Data/ContentRepositories/ContentRepository.swift
+++ b/Emitron/Emitron/Data/ContentRepositories/ContentRepository.swift
@@ -138,7 +138,6 @@ class ContentRepository: ObservableObject, ContentPaginatable {
 
   // MARK: -
 
-
   var nonPaginationParameters: [Parameter] = [] {
     didSet {
       if state != .initial {

--- a/Emitron/Emitron/UI/Shared/Content Detail/ContentDetailView.swift
+++ b/Emitron/Emitron/UI/Shared/Content Detail/ContentDetailView.swift
@@ -55,16 +55,18 @@ struct ContentDetailView {
 // MARK: - View
 extension ContentDetailView: View {
   var body: some View {
-    if let model = currentlyDisplayedVideoPlaybackViewModel {
-      try? FullScreenVideoPlayer(
-        model: model,
-        messageBus: messageBus,
-        handleDismissal: {
-          currentlyDisplayedVideoPlaybackViewModel = nil
-        }
-      )
-    } else {
+    ZStack {
       contentView
+
+      if let model = currentlyDisplayedVideoPlaybackViewModel {
+        try? FullScreenVideoPlayer(
+          model: model,
+          messageBus: messageBus,
+          handleDismissal: {
+            currentlyDisplayedVideoPlaybackViewModel = nil
+          }
+        )
+      }
     }
   }
 }


### PR DESCRIPTION
With the previous commit, I missed that the content was turning blank underneath the transition.