### PR TITLE
Fix Minor SwiftLint Warning Colon Spacing Violation:

### DIFF
--- a/Emitron/Emitron/UI/App Root/MainView.swift
+++ b/Emitron/Emitron/UI/App Root/MainView.swift
@@ -75,7 +75,7 @@ private extension MainView {
   
   @ViewBuilder var tabBarView: some View {
     switch sessionController.sessionState {
-    case .online :
+    case .online:
       TabView(
         libraryView: {
           LibraryView(


### PR DESCRIPTION
This PR fixes a Minor SwiftLint Warning Colon Spacing Violation:
Colons should be next to the identifier when specifying a type and next to the key in dictionary literals. (colon)
