### PR TITLE
Fixed Xcode 14 Warning for the Run script build phase 

### DIFF
--- a/Emitron/Emitron.xcodeproj/project.pbxproj
+++ b/Emitron/Emitron.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 52;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -1894,6 +1894,7 @@
 /* Begin PBXShellScriptBuildPhase section */
 		222DD7F4233B9A9900CF561F /* Set Build Number */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
@@ -1912,6 +1913,7 @@
 		};
 		958699B722D48F3E00E33625 /* SwiftLint Run Script */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);


### PR DESCRIPTION
This PR fixes the warning build: Run script build phase 'SwiftLint Run Script' will be run during every build because it does not specify any outputs.

<img width="563" alt="image" src="https://user-images.githubusercontent.com/4116539/191912180-1ce40a35-975f-4081-b11c-8cf64e2cbdc4.png">

By unchecking "Based on dependency analysis" in the script phase thus configured to run in every build.
