### PR TITLE
(FIX) Restoring the Library title on the Library screen

### DIFF
--- a/Emitron/Emitron/UI/Library/LibraryView.swift
+++ b/Emitron/Emitron/UI/Library/LibraryView.swift
@@ -45,6 +45,7 @@ struct LibraryView: View {
 
   var body: some View {
     contentView
+      .navigationBarTitle(String.library, displayMode: .inline)
       .sheet(isPresented: $filtersPresented) {
         FiltersView(libraryRepository: libraryRepository, filters: filters)
           .background(Color.background.edgesIgnoringSafeArea(.all))


### PR DESCRIPTION
<!-- 🚀 Thank you for contributing! -->

<!-- Describe your changes clearly and use examples if possible. -->
This PR fixes #689 

It looks like the Navigation title was removed on purpose. I assume it was done to save a bit of extra space for the rest of content.

I've brought the navigation title back but kept it inline as a compromise between the scrolling issue and still having sufficient amount of space.

| Before | After |
|--|--|
|<img src="https://user-images.githubusercontent.com/4711044/217467845-bcbc0883-9d4d-431a-b68d-218c4850c68c.mp4" /> | <img src="https://user-images.githubusercontent.com/4711044/217467979-f1cc5d66-5dae-4ce7-8b6c-20b8a6b8ac08.mp4" />|


<!-- If this PR fixes an issue, then please link to that issue. If the PR
  is large (or likely to be), it would be prudent to open a discussion in
  advance of the PR to avoid doing large amounts of work that might not
  get merged. -->



<!-- When this PR is merged, a new version of emitron will be pushed to Testflight automatically -->
